### PR TITLE
Added more resilience to port connection on the server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@playcanvas/eslint-config": "^2.0.9",
+        "@types/node": "^22.13.11",
         "@types/ws": "^8.18.0",
         "@typescript-eslint/parser": "^8.27.0",
         "eslint": "^9.22.0",
@@ -800,7 +801,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.10",
+      "version": "22.13.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.11.tgz",
+      "integrity": "sha512-iEUCUJoU0i3VnrCmgoWCXttklWcvoCIx4jzcP22fioIVSdTmjgoEvmAO/QPw6TcS9k5FrNgn4w7q5lGOd1CT5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@playcanvas/eslint-config": "^2.0.9",
+    "@types/node": "^22.13.11",
     "@types/ws": "^8.18.0",
     "@typescript-eslint/parser": "^8.27.0",
     "eslint": "^9.22.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import child_process, { execSync } from 'child_process';
+import net from 'net';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -12,44 +13,125 @@ import { register as registerStore } from './tools/store.ts';
 import { WSS } from './wss.ts';
 
 const PORT = 52000;
+const MAX_RETRIES = 5;
+const RETRY_DELAY = 1000; // 1 second
 
-// Kill existing processes
-if (process.platform === 'win32') {
-    const cmd = `netstat -ano | findstr 0.0.0.0:${PORT}`;
-    const proc = child_process.spawnSync('cmd', ['/c', cmd], { shell: true });
-    const pid = proc.stdout.toString().replace(/\s+/g, ' ').trim().split(' ').pop();
-    if (pid) {
-        child_process.spawnSync('taskkill', ['/F', '/PID', pid, '/T']);
-    }
-} else {
-    // Kill any process using the port
-    try {
-        execSync(`lsof -ti :${PORT} | xargs kill -9`);
-    } catch (err) {
-        // Do nothing
+/**
+ * Check if a port is in use
+ */
+function isPortInUse(port: number): Promise<boolean> {
+    return new Promise((resolve) => {
+        const server = net.createServer()
+        .once('error', () => {
+            // Port is in use
+            resolve(true);
+        })
+        .once('listening', () => {
+            // Port is free
+            server.close();
+            resolve(false);
+        })
+        .listen(port);
+    });
+}
+
+/**
+ * Kill any process using the specified port
+ */
+function killProcessOnPort(port: number): void {
+    if (process.platform === 'win32') {
+        const cmd = `netstat -ano | findstr 0.0.0.0:${port}`;
+        const proc = child_process.spawnSync('cmd', ['/c', cmd], { shell: true });
+        const pid = proc.stdout.toString().replace(/\s+/g, ' ').trim().split(' ').pop();
+        if (pid) {
+            child_process.spawnSync('taskkill', ['/F', '/PID', pid, '/T']);
+        }
+    } else {
+        // Kill any process using the port
+        try {
+            execSync(`lsof -ti :${port} | xargs kill -9`);
+        } catch (err) {
+            // Do nothing
+        }
     }
 }
 
-// Create a WebSocket server
-const wss = new WSS(PORT);
-setInterval(() => {
-    wss.call('ping');
-}, 1000);
+/**
+ * Sleep for a specified amount of time
+ */
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
 
-// Create an MCP server
-const server = new McpServer({
-    name: 'PlayCanvas',
-    version: '1.0.0'
+/**
+ * Try to create a WSS server on the specified port
+ */
+async function tryCreateServer(): Promise<WSS | null> {
+    // Check if port is in use
+    const portInUse = await isPortInUse(PORT);
+
+    if (portInUse) {
+        console.log(`Port ${PORT} is busy. Attempting to free it...`);
+        // Kill any process using the port
+        killProcessOnPort(PORT);
+        return null;
+    }
+
+    // Port is free, create the server
+    console.log(`Port ${PORT} is available. Starting server...`);
+    return new WSS(PORT);
+}
+
+/**
+ * Initialize the WebSocket server with retry logic using a recursive approach
+ */
+async function initializeServer(retriesLeft = MAX_RETRIES): Promise<WSS> {
+    if (retriesLeft <= 0) {
+        throw new Error(`Failed to start server: Port ${PORT} is still in use after ${MAX_RETRIES} attempts.`);
+    }
+
+    const server = await tryCreateServer();
+
+    if (server) {
+        return server;
+    }
+
+    // Wait before trying again
+    await sleep(RETRY_DELAY);
+
+    // Recursively try again with one less retry
+    return initializeServer(retriesLeft - 1);
+}
+
+// Start the server
+(async () => {
+    // Create a WebSocket server with retry logic
+    const wss = await initializeServer();
+
+    setInterval(() => {
+        wss.call('ping');
+    }, 1000);
+
+    // Create an MCP server
+    const server = new McpServer({
+        name: 'PlayCanvas',
+        version: '1.0.0'
+    });
+
+    // Register tools
+    registerEntity(server, wss);
+    registerAsset(server, wss);
+    registerAssetMaterial(server, wss);
+    registerAssetScript(server, wss);
+    registerScene(server, wss);
+    registerStore(server, wss);
+
+    // Start receiving messages on stdin and sending messages on stdout
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+})().catch((err) => {
+    console.error('Server initialization failed:', err);
+    process.exit(1);
 });
-
-// Register tools
-registerEntity(server, wss);
-registerAsset(server, wss);
-registerAssetMaterial(server, wss);
-registerAssetScript(server, wss);
-registerScene(server, wss);
-registerStore(server, wss);
-
-// Start receiving messages on stdin and sending messages on stdout
-const transport = new StdioServerTransport();
-await server.connect(transport);


### PR DESCRIPTION
Port Connection Resilience Improvements
This PR addresses an issue where the MCP server would fail when port 52000 was already in use. Instead of immediately failing, the server now tries to free the port and retry the connection.

Changes Made
Added port availability detection using Node.js net module
Implemented a robust retry mechanism that:
Checks if port 52000 is in use
Attempts to kill any process using the port
Waits and retries up to 5 times (configurable via MAX_RETRIES)
Provides clear error messages if ultimately unsuccessful
Implementation Details
Added helper functions for better code organization:
isPortInUse(): Checks if a port is already in use
killProcessOnPort(): Platform-specific port cleanup
sleep(): Promise-based timeout utility
tryCreateServer(): Attempts to create a server once
initializeServer(): Recursive retry logic

Testing
Tested on both Windows and Mac environments with various scenarios:
Clean start (port available)
Port in use by another process
Multiple retries required

Benefits
Improves server reliability by handling port conflicts
Provides better user experience with informative logging
Follows best practices with proper error handling and clean code structure