### PR TITLE
[FIX] Fix error handling in entity methods

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -260,14 +260,14 @@
         return { data: entities.map((entity) => entity.json()) };
     });
     wsc.method('entities:modify', (edits) => {
-        edits.forEach(({ id, path, value }) => {
+        for (const { id, path, value } of edits) {
             const entity = api.entities.get(id);
             if (!entity) {
-                return { error: 'Entity not found' };
+                return { error: `Entity not found: ${id}` };
             }
             entity.set(path, value);
             log(`Set property(${path}) of entity(${id}) to: ${JSON.stringify(value)}`);
-        });
+        }
         return { data: true };
     });
     wsc.method('entities:duplicate', async (ids, options = {}) => {


### PR DESCRIPTION
Fixes a bug where errors inside `entities:create` and `entities:modify` were silently ignored.

### Problem

The `return { error }` inside a `forEach` callback only exits the callback, not the outer function:

```javascript
// Before (broken)
entityDataArray.forEach((entityData) => {
    if (!parent) return { error: '...' };  // Ignored!
});
```

### Solution

Changed `forEach` to `for...of` so errors properly return to the caller:

```javascript
// After (fixed)
for (const entityData of entityDataArray) {
    if (!parent) return { error: '...' };  // Works correctly
}
```

### Changes

- `entities:create`: Use `for...of` instead of `forEach`
- `entities:modify`: Use `for...of` instead of `forEach`, include entity ID in error message