### PR TITLE
Migrate to registerTool

### DIFF
--- a/src/tools/asset.ts
+++ b/src/tools/asset.ts
@@ -5,56 +5,64 @@ import { type WSS } from '../wss';
 import { CssCreateSchema, FolderCreateSchema, HtmlCreateSchema, MaterialCreateSchema, ScriptCreateSchema, ShaderCreateSchema, TemplateCreateSchema, TextCreateSchema } from './schema/asset';
 import { AssetIdSchema } from './schema/common';
 
-export const register = (mcp: McpServer, wss: WSS) => {
-    mcp.tool(
+export const register = (server: McpServer, wss: WSS) => {
+    server.registerTool(
         'create_assets',
-        'Create one or more assets',
         {
-            assets: z.array(
-                z.union([
-                    CssCreateSchema,
-                    FolderCreateSchema,
-                    HtmlCreateSchema,
-                    MaterialCreateSchema,
-                    ScriptCreateSchema,
-                    ShaderCreateSchema,
-                    TemplateCreateSchema,
-                    TextCreateSchema
-                ])
-            ).nonempty().describe('Array of assets to create.')
+            description: 'Create one or more assets',
+            inputSchema: {
+                assets: z.array(
+                    z.union([
+                        CssCreateSchema,
+                        FolderCreateSchema,
+                        HtmlCreateSchema,
+                        MaterialCreateSchema,
+                        ScriptCreateSchema,
+                        ShaderCreateSchema,
+                        TemplateCreateSchema,
+                        TextCreateSchema
+                    ])
+                ).nonempty().describe('Array of assets to create.')
+            }
         },
         ({ assets }) => {
             return wss.call('assets:create', assets);
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'list_assets',
-        'List all assets with the option to filter by type',
         {
-            type: z.enum(['css', 'cubemap', 'folder', 'font', 'html', 'json', 'material', 'render', 'script', 'shader', 'template', 'text', 'texture']).optional().describe('The type of assets to list. If not specified, all assets will be listed.')
+            description: 'List all assets with the option to filter by type',
+            inputSchema: {
+                type: z.enum(['css', 'cubemap', 'folder', 'font', 'html', 'json', 'material', 'render', 'script', 'shader', 'template', 'text', 'texture']).optional().describe('The type of assets to list. If not specified, all assets will be listed.')
+            }
         },
         ({ type }) => {
             return wss.call('assets:list', type);
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'delete_assets',
-        'Delete one or more assets',
         {
-            ids: z.array(AssetIdSchema).nonempty().describe('The asset IDs of the assets to delete')
+            description: 'Delete one or more assets',
+            inputSchema: {
+                ids: z.array(AssetIdSchema).nonempty().describe('The asset IDs of the assets to delete')
+            }
         },
         ({ ids }) => {
             return wss.call('assets:delete', ids);
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'instantiate_template_assets',
-        'Instantiate one or more template assets',
         {
-            ids: z.array(AssetIdSchema).nonempty().describe('The asset IDs of the template assets to instantiate')
+            description: 'Instantiate one or more template assets',
+            inputSchema: {
+                ids: z.array(AssetIdSchema).nonempty().describe('The asset IDs of the template assets to instantiate')
+            }
         },
         ({ ids }) => {
             return wss.call('assets:instantiate', ids);

--- a/src/tools/assets/material.ts
+++ b/src/tools/assets/material.ts
@@ -3,13 +3,15 @@ import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { type WSS } from '../../wss';
 import { AssetIdSchema, RgbSchema } from '../schema/common';
 
-export const register = (mcp: McpServer, wss: WSS) => {
-    mcp.tool(
+export const register = (server: McpServer, wss: WSS) => {
+    server.registerTool(
         'set_material_diffuse',
-        'Set diffuse property on a material',
         {
-            assetId: AssetIdSchema,
-            color: RgbSchema
+            description: 'Set diffuse property on a material',
+            inputSchema: {
+                assetId: AssetIdSchema,
+                color: RgbSchema
+            }
         },
         ({ assetId, color }) => {
             return wss.call('assets:property:set', assetId, 'diffuse', color);

--- a/src/tools/assets/script.ts
+++ b/src/tools/assets/script.ts
@@ -3,24 +3,28 @@ import { z } from 'zod';
 
 import { type WSS } from '../../wss';
 
-export const register = (mcp: McpServer, wss: WSS) => {
-    mcp.tool(
+export const register = (server: McpServer, wss: WSS) => {
+    server.registerTool(
         'set_script_text',
-        'Set script text',
         {
-            assetId: z.number(),
-            text: z.string()
+            description: 'Set script text',
+            inputSchema: {
+                assetId: z.number(),
+                text: z.string()
+            }
         },
         ({ assetId, text }) => {
             return wss.call('assets:script:text:set', assetId, text);
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'script_parse',
-        'Parse the script after modification',
         {
-            assetId: z.number()
+            description: 'Parse the script after modification',
+            inputSchema: {
+                assetId: z.number()
+            }
         },
         ({ assetId }) => {
             return wss.call('assets:script:parse', assetId);

--- a/src/tools/entity.ts
+++ b/src/tools/entity.ts
@@ -5,112 +5,129 @@ import { type WSS } from '../wss';
 import { EntityIdSchema } from './schema/common';
 import { ComponentsSchema, ComponentNameSchema, EntitySchema } from './schema/entity';
 
-export const register = (mcp: McpServer, wss: WSS) => {
-    mcp.tool(
+export const register = (server: McpServer, wss: WSS) => {
+    server.registerTool(
         'create_entities',
-        'Create one or more entities',
         {
-            entities: z.array(z.object({
-                entity: EntitySchema,
-                parent: EntityIdSchema.optional().describe('The parent entity to create the entity under. If not provided, the root entity will be used.')
-            })).nonempty().describe('Array of entity hierarchies to create.')
+            description: 'Create one or more entities',
+            inputSchema: {
+                entities: z.array(z.object({
+                    entity: EntitySchema,
+                    parent: EntityIdSchema.optional().describe('The parent entity to create the entity under. If not provided, the root entity will be used.')
+                })).nonempty().describe('Array of entity hierarchies to create.')
+            }
         },
         ({ entities }) => {
             return wss.call('entities:create', entities);
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'modify_entities',
-        'Modify one or more entity\'s properties',
         {
-            edits: z.array(z.object({
-                id: EntityIdSchema,
-                path: z.string().describe('The path to the property to modify. Use dot notation to access nested properties.'),
-                value: z.any().describe('The value to set the property to.')
-            })).nonempty().describe('An array of objects containing the ID of the entity to modify, the path to the property to modify, and the value to set the property to.')
+            description: 'Modify one or more entity\'s properties',
+            inputSchema: {
+                edits: z.array(z.object({
+                    id: EntityIdSchema,
+                    path: z.string().describe('The path to the property to modify. Use dot notation to access nested properties.'),
+                    value: z.any().describe('The value to set the property to.')
+                })).nonempty().describe('An array of objects containing the ID of the entity to modify, the path to the property to modify, and the value to set the property to.')
+            }
         },
         ({ edits }) => {
             return wss.call('entities:modify', edits);
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'duplicate_entities',
-        'Duplicate one or more entities',
         {
-            ids: z.array(EntityIdSchema).nonempty().describe('Array of entity IDs to duplicate. The root entity cannot be duplicated.'),
-            rename: z.boolean().optional()
+            description: 'Duplicate one or more entities',
+            inputSchema: {
+                ids: z.array(EntityIdSchema).nonempty().describe('Array of entity IDs to duplicate. The root entity cannot be duplicated.'),
+                rename: z.boolean().optional()
+            }
         },
         ({ ids, rename }) => {
             return wss.call('entities:duplicate', ids, { rename });
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'reparent_entity',
-        'Reparent an entity',
         {
-            id: EntityIdSchema,
-            parent: EntityIdSchema,
-            index: z.number().optional(),
-            preserveTransform: z.boolean().optional()
+            description: 'Reparent an entity',
+            inputSchema: {
+                id: EntityIdSchema,
+                parent: EntityIdSchema,
+                index: z.number().optional(),
+                preserveTransform: z.boolean().optional()
+            }
         },
         (options) => {
             return wss.call('entities:reparent', options);
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'delete_entities',
-        'Delete one or more entities. The root entity cannot be deleted.',
         {
-            ids: z.array(EntityIdSchema).nonempty().describe('Array of entity IDs to delete. The root entity cannot be deleted.')
+            description: 'Delete one or more entities. The root entity cannot be deleted.',
+            inputSchema: {
+                ids: z.array(EntityIdSchema).nonempty().describe('Array of entity IDs to delete. The root entity cannot be deleted.')
+            }
         },
         ({ ids }) => {
             return wss.call('entities:delete', ids);
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'list_entities',
-        'List all entities',
-        {},
+        {
+            description: 'List all entities'
+        },
         () => {
             return wss.call('entities:list');
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'add_components',
-        'Add components to an entity',
         {
-            id: EntityIdSchema,
-            components: ComponentsSchema
+            description: 'Add components to an entity',
+            inputSchema: {
+                id: EntityIdSchema,
+                components: ComponentsSchema
+            }
         },
         ({ id, components }) => {
             return wss.call('entities:components:add', id, components);
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'remove_components',
-        'Remove components from an entity',
         {
-            id: EntityIdSchema,
-            components: z.array(ComponentNameSchema).nonempty().describe('Array of component names to remove from the entity.')
+            description: 'Remove components from an entity',
+            inputSchema: {
+                id: EntityIdSchema,
+                components: z.array(ComponentNameSchema).nonempty().describe('Array of component names to remove from the entity.')
+            }
         },
         ({ id, components }) => {
             return wss.call('entities:components:remove', id, components);
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'add_script_component_script',
-        'Add a script to a script component',
         {
-            id: EntityIdSchema,
-            scriptName: z.string()
+            description: 'Add a script to a script component',
+            inputSchema: {
+                id: EntityIdSchema,
+                scriptName: z.string()
+            }
         },
         ({ id, scriptName }) => {
             return wss.call('entities:components:script:add', id, scriptName);

--- a/src/tools/scene.ts
+++ b/src/tools/scene.ts
@@ -3,22 +3,25 @@ import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { type WSS } from '../wss';
 import { SceneSettingsSchema } from './schema/scene-settings';
 
-export const register = (mcp: McpServer, wss: WSS) => {
-    mcp.tool(
+export const register = (server: McpServer, wss: WSS) => {
+    server.registerTool(
         'modify_scene_settings',
-        'Modify the scene settings',
         {
-            settings: SceneSettingsSchema
+            description: 'Modify the scene settings',
+            inputSchema: {
+                settings: SceneSettingsSchema
+            }
         },
         ({ settings }) => {
             return wss.call('scene:settings:modify', settings);
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'query_scene_settings',
-        'Query the scene settings',
-        {},
+        {
+            description: 'Query the scene settings'
+        },
         () => {
             return wss.call('scene:settings:modify', {});
         }

--- a/src/tools/store.ts
+++ b/src/tools/store.ts
@@ -8,16 +8,18 @@ const orderEnum = {
     'desc': -1
 };
 
-export const register = (mcp: McpServer, wss: WSS) => {
-    mcp.tool(
+export const register = (server: McpServer, wss: WSS) => {
+    server.registerTool(
         'store_search',
-        'Search for an asset in the store',
         {
-            // store: z.enum(['playcanvas', 'sketchfab']).optional(),
-            search: z.string(),
-            order: z.enum(['asc', 'desc']).optional(),
-            skip: z.number().optional(),
-            limit: z.number().optional()
+            description: 'Search for an asset in the store',
+            inputSchema: {
+                // store: z.enum(['playcanvas', 'sketchfab']).optional(),
+                search: z.string(),
+                order: z.enum(['asc', 'desc']).optional(),
+                skip: z.number().optional(),
+                limit: z.number().optional()
+            }
         },
         ({ search, order, skip, limit }) => {
             return wss.call('store:playcanvas:list', {
@@ -29,30 +31,34 @@ export const register = (mcp: McpServer, wss: WSS) => {
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'store_get',
-        'Get an asset from the store',
         {
-            // store: z.enum(['playcanvas', 'sketchfab']).optional(),
-            id: z.string()
+            description: 'Get an asset from the store',
+            inputSchema: {
+                // store: z.enum(['playcanvas', 'sketchfab']).optional(),
+                id: z.string()
+            }
         },
         ({ id }) => {
             return wss.call('store:playcanvas:get', id);
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'store_download',
-        'Download an asset from the store',
         {
-            // store: z.enum(['playcanvas', 'sketchfab']).optional(),
-            id: z.string(),
-            name: z.string(),
-            license: z.object({
-                author: z.string(),
-                authorUrl: z.string().url(),
-                license: z.string()
-            })
+            description: 'Download an asset from the store',
+            inputSchema: {
+                // store: z.enum(['playcanvas', 'sketchfab']).optional(),
+                id: z.string(),
+                name: z.string(),
+                license: z.object({
+                    author: z.string(),
+                    authorUrl: z.string().url(),
+                    license: z.string()
+                })
+            }
         },
         ({ id, name, license }) => {
             return wss.call('store:playcanvas:clone', id, name, license);

--- a/src/tools/viewport.ts
+++ b/src/tools/viewport.ts
@@ -4,24 +4,27 @@ import { z } from 'zod';
 import { type WSS } from '../wss';
 import { EntityIdSchema } from './schema/common';
 
-export const register = (mcp: McpServer, wss: WSS) => {
-    mcp.tool(
+export const register = (server: McpServer, wss: WSS) => {
+    server.registerTool(
         'capture_viewport',
-        'Capture a screenshot of the Editor viewport. Use this to visually verify what you have built.',
-        {},
+        {
+            description: 'Capture a screenshot of the Editor viewport. Use this to visually verify what you have built.'
+        },
         () => {
             return wss.callImage('viewport:capture');
         }
     );
 
-    mcp.tool(
+    server.registerTool(
         'focus_viewport',
-        'Select entities and focus the Editor viewport camera on them. Optionally specify a camera viewpoint.',
         {
-            ids: z.array(EntityIdSchema).nonempty().describe('Array of entity IDs to select and focus on'),
-            view: z.enum(['top', 'bottom', 'front', 'back', 'left', 'right', 'perspective']).optional().describe('Preset camera view. Mutually exclusive with yaw/pitch.'),
-            yaw: z.number().min(-180).max(180).optional().describe('Horizontal angle in degrees (-180 to 180). 0=front, 90=right, -90=left, 180=back'),
-            pitch: z.number().min(-90).max(90).optional().describe('Vertical angle in degrees (-90 to 90). 0=level, -90=top-down, 90=bottom-up')
+            description: 'Select entities and focus the Editor viewport camera on them. Optionally specify a camera viewpoint.',
+            inputSchema: {
+                ids: z.array(EntityIdSchema).nonempty().describe('Array of entity IDs to select and focus on'),
+                view: z.enum(['top', 'bottom', 'front', 'back', 'left', 'right', 'perspective']).optional().describe('Preset camera view. Mutually exclusive with yaw/pitch.'),
+                yaw: z.number().min(-180).max(180).optional().describe('Horizontal angle in degrees (-180 to 180). 0=front, 90=right, -90=left, 180=back'),
+                pitch: z.number().min(-90).max(90).optional().describe('Vertical angle in degrees (-90 to 90). 0=level, -90=top-down, 90=bottom-up')
+            }
         },
         ({ ids, view, yaw, pitch }) => {
             return wss.call('viewport:focus', ids, { view, yaw, pitch });


### PR DESCRIPTION
Migrates all tool registrations from the deprecated `mcp.tool()` to `mcp.registerTool()` API introduced in `@modelcontextprotocol/sdk` v1.25+.

### Changes

- Replace `tool(name, description, schema, callback)` with `registerTool(name, { description, inputSchema }, callback)`
- Rename `mcp` parameter to `server` for clarity
- Tools with no parameters now omit `inputSchema` instead of passing `{}`

### Files Updated

- `src/tools/entity.ts` (9 tools)
- `src/tools/asset.ts` (4 tools)
- `src/tools/scene.ts` (2 tools)
- `src/tools/store.ts` (3 tools)
- `src/tools/viewport.ts` (2 tools)
- `src/tools/assets/material.ts` (1 tool)
- `src/tools/assets/script.ts` (2 tools)

**Total: 23 tools migrated**