### PR TITLE
[FIX] Fix query_scene_settings after response optimization

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -629,6 +629,11 @@
         log('Modified scene settings');
         return { data: true };
     });
+    wsc.method('scene:settings:query', () => {
+        const scene = api.settings.scene;
+        log('Queried scene settings');
+        return { data: scene.json() };
+    });
 
     // store
 

--- a/src/tools/scene.ts
+++ b/src/tools/scene.ts
@@ -23,7 +23,7 @@ export const register = (server: McpServer, wss: WSS) => {
             description: 'Query the scene settings'
         },
         () => {
-            return wss.call('scene:settings:modify', {});
+            return wss.call('scene:settings:query');
         }
     );
 };


### PR DESCRIPTION
Adds dedicated `scene:settings:query` method to properly return scene settings JSON.

Previously `query_scene_settings` reused `scene:settings:modify` with empty input, but after optimizing that method to return `true`, queries returned no data. Now read and write operations are properly separated.