### PR TITLE
Token-Efficient List Tools

### DIFF
--- a/src/tools/asset.ts
+++ b/src/tools/asset.ts
@@ -33,13 +33,16 @@ export const register = (server: McpServer, wss: WSS) => {
     server.registerTool(
         'list_assets',
         {
-            description: 'List assets',
+            description: 'List assets. Returns summary by default (id, name, type, folder, tags). Use full=true for complete asset data.',
             inputSchema: {
-                type: z.enum(['css', 'cubemap', 'folder', 'font', 'html', 'json', 'material', 'render', 'script', 'shader', 'template', 'text', 'texture']).optional().describe('Filter by type')
+                full: z.boolean().optional().describe('Return full asset JSON instead of summary'),
+                type: z.enum(['css', 'cubemap', 'folder', 'font', 'html', 'json', 'material', 'render', 'script', 'shader', 'template', 'text', 'texture']).optional().describe('Filter by type'),
+                name: z.string().optional().describe('Filter by name (case-insensitive contains)'),
+                tag: z.string().optional().describe('Filter by tag')
             }
         },
-        ({ type }) => {
-            return wss.call('assets:list', type);
+        (options) => {
+            return wss.call('assets:list', options);
         }
     );
 

--- a/src/tools/entity.ts
+++ b/src/tools/entity.ts
@@ -85,10 +85,16 @@ export const register = (server: McpServer, wss: WSS) => {
     server.registerTool(
         'list_entities',
         {
-            description: 'List all entities'
+            description: 'List entities. Returns summary by default (id, name, parent, enabled, tags, components). Use full=true for complete entity data.',
+            inputSchema: {
+                full: z.boolean().optional().describe('Return full entity JSON instead of summary'),
+                name: z.string().optional().describe('Filter by name (case-insensitive contains)'),
+                component: ComponentNameSchema.optional().describe('Filter by component type'),
+                tag: z.string().optional().describe('Filter by tag')
+            }
         },
-        () => {
-            return wss.call('entities:list');
+        (options) => {
+            return wss.call('entities:list', options);
         }
     );
 


### PR DESCRIPTION
Reduces token usage for `list_entities` and `list_assets` tools by returning summary data by default instead of full JSON.

Fixes #66

### Changes

**Summary Mode (Default)**
- `list_entities` returns: `{ resource_id, name, parent, enabled, tags, components[] }`
- `list_assets` returns: `{ id, name, type, folder, tags }`

**New Parameters**
- `full` (boolean) - Returns complete JSON when true
- `name` (string) - Filter by name (case-insensitive contains)
- `tag` (string) - Filter by tag
- `component` (string, entities only) - Filter by component type

### Example Usage

```javascript
// Get all entities with cameras (summary)
list_entities({ component: 'camera' })

// Get full details for entities named "Player"
list_entities({ name: 'Player', full: true })

// Get all script assets (summary)
list_assets({ type: 'script' })
```

### Token Savings

A typical entity returns ~50-200+ properties in full mode. Summary mode reduces this to 6 properties per entity - roughly **90%+ reduction** in token usage for list operations.