### PR TITLE
Fix tuple-based schemas for Claude Code compatibility

### DIFF
--- a/src/tools/schema/common.ts
+++ b/src/tools/schema/common.ts
@@ -1,35 +1,13 @@
 import { z } from 'zod';
 
-export const RgbSchema = z.tuple([
-    z.number().min(0).max(1),
-    z.number().min(0).max(1),
-    z.number().min(0).max(1)
-]).describe('RGB color [r,g,b] 0-1');
+export const RgbSchema = z.array(z.number().min(0).max(1)).length(3).describe('RGB color [r,g,b] 0-1');
 
-export const RgbaSchema = z.tuple([
-    z.number().min(0).max(1),
-    z.number().min(0).max(1),
-    z.number().min(0).max(1),
-    z.number().min(0).max(1)
-]).describe('RGBA color [r,g,b,a] 0-1');
+export const RgbaSchema = z.array(z.number().min(0).max(1)).length(4).describe('RGBA color [r,g,b,a] 0-1');
 
-export const Vec2Schema = z.tuple([
-    z.number(),
-    z.number()
-]).describe('[x,y]');
+export const Vec2Schema = z.array(z.number()).length(2).describe('[x,y]');
 
-export const Vec3Schema = z.tuple([
-    z.number(),
-    z.number(),
-    z.number()
-]).describe('[x,y,z]');
+export const Vec3Schema = z.array(z.number()).length(3).describe('[x,y,z]');
 
-export const Vec4Schema = z.tuple([
-    z.number(),
-    z.number(),
-    z.number(),
-    z.number()
-]).describe('[x,y,z,w]');
-
+export const Vec4Schema = z.array(z.number()).length(4).describe('[x,y,z,w]');
 export const AssetIdSchema = z.number().int().nullable().describe('Asset ID');
 export const EntityIdSchema = z.string().uuid().describe('Entity ID');


### PR DESCRIPTION
```md
  ## Summary
  - replace shared `z.tuple(...)` vector/color schemas with fixed-length
  `z.array(...).length(n)` schemas
  - make generated tool JSON Schema compatible with Claude Code's parameter
  validation
  - keep the same runtime validation semantics for vector and color inputs

  ## Test plan
  - [x] Run TypeScript check
  - [x] Run ESLint
  - [x] Verify generated JSON Schema uses `items: { ... }` with
  `minItems`/`maxItems`