### PR TITLE
fix(wss): add 30s timeout to _send() to prevent silent hangs on large…

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -299,10 +299,13 @@
 
             // Convert to base64 WebP for smaller file size (falls back to PNG if unsupported)
             const dataUrl = dstCanvas.toDataURL('image/webp', 0.8);
+            // Derive the actual mime type from the data URL header, since the browser
+            // may fall back to PNG when WebP is unsupported.
+            const mimeType = (dataUrl.match(/^data:([^;,]+)/) || [])[1] || 'image/png';
             const base64 = dataUrl.split(',')[1];
 
             log(`Captured viewport screenshot (${dstWidth}x${dstHeight})`);
-            return { data: base64, mimeType: 'image/webp' };
+            return { data: base64, mimeType };
         } catch (e) {
             return { error: `Failed to capture viewport: ${e.message}` };
         }

--- a/extension/main.js
+++ b/extension/main.js
@@ -302,7 +302,7 @@
             const base64 = dataUrl.split(',')[1];
 
             log(`Captured viewport screenshot (${dstWidth}x${dstHeight})`);
-            return { data: base64 };
+            return { data: base64, mimeType: 'image/webp' };
         } catch (e) {
             return { error: `Failed to capture viewport: ${e.message}` };
         }

--- a/src/wss.ts
+++ b/src/wss.ts
@@ -57,7 +57,15 @@ class WSS {
     }
 
     private _send(name: string, ...args: any[]) {
-        return new Promise<{ data?: any, error?: string }>((resolve, reject) => {
+        return new Promise<{ data?: any, error?: string, mimeType?: string }>((resolve, reject) => {
+            if (!this._socket) {
+                reject(new Error('No socket'));
+                return;
+            }
+            if (this._socket.readyState !== WebSocket.OPEN) {
+                reject(new Error('Socket not open'));
+                return;
+            }
             const id = this._id++;
             const timer = setTimeout(() => {
                 this._callbacks.delete(id);
@@ -67,17 +75,13 @@ class WSS {
                 clearTimeout(timer);
                 resolve(res);
             });
-            if (!this._socket) {
+            try {
+                this._socket.send(JSON.stringify({ id, name, args }));
+            } catch (err: any) {
                 clearTimeout(timer);
-                reject(new Error('No socket'));
-                return;
+                this._callbacks.delete(id);
+                reject(new Error(`[WSS] Send failed: ${err.message}`));
             }
-            if (this._socket.readyState !== WebSocket.OPEN) {
-                clearTimeout(timer);
-                reject(new Error('Socket not open'));
-                return;
-            }
-            this._socket.send(JSON.stringify({ id, name, args }));
         });
     }
 

--- a/src/wss.ts
+++ b/src/wss.ts
@@ -1,6 +1,7 @@
 import { WebSocketServer, WebSocket } from 'ws';
 
 const PING_DELAY = 1000;
+const DEFAULT_TIMEOUT = 30_000;
 
 class WSS {
     private _server: WebSocketServer;
@@ -58,12 +59,21 @@ class WSS {
     private _send(name: string, ...args: any[]) {
         return new Promise<{ data?: any, error?: string }>((resolve, reject) => {
             const id = this._id++;
-            this._callbacks.set(id, resolve);
+            const timer = setTimeout(() => {
+                this._callbacks.delete(id);
+                reject(new Error(`[WSS] Timeout: '${name}' after ${DEFAULT_TIMEOUT}ms`));
+            }, DEFAULT_TIMEOUT);
+            this._callbacks.set(id, (res: any) => {
+                clearTimeout(timer);
+                resolve(res);
+            });
             if (!this._socket) {
+                clearTimeout(timer);
                 reject(new Error('No socket'));
                 return;
             }
             if (this._socket.readyState !== WebSocket.OPEN) {
+                clearTimeout(timer);
                 reject(new Error('Socket not open'));
                 return;
             }
@@ -96,15 +106,18 @@ class WSS {
 
     async callImage(name: string, ...args: any[]): Promise<{ content: any[], isError?: boolean }> {
         try {
-            const { data, error } = await this._send(name, ...args);
+            const { data, error, mimeType } = await this._send(name, ...args);
             if (error) {
                 throw new Error(error);
+            }
+            if (!data || typeof data !== 'string' || data.trim().length === 0) {
+                throw new Error('No image data received — viewport may be empty or not yet rendered');
             }
             return {
                 content: [{
                     type: 'image',
                     data: data,
-                    mimeType: 'image/jpeg'
+                    mimeType: mimeType || 'image/png'
                 }]
             };
         } catch (err: any) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/editor-mcp-server/issues/84

# Summary

- Add a 30s default timeout to `WSS._send()` (`DEFAULT_TIMEOUT = 30_000`) so large requests (e.g. screenshots, asset creation) no longer hang silently when the client never responds. The pending callback is cleaned up and the timer is cleared on timeout, socket errors, and successful resolution.
- Harden `callImage()`: validate that image data is actually received before returning (throws a clear error when the viewport is empty / not yet rendered), and forward the `mimeType` reported by the client instead of hardcoding `image/jpeg` (falls back to `image/png`).
- `extension/main.js`: viewport screenshots now report `mimeType: 'image/webp'` so the server forwards the correct type.

## Changes

| File | Description |
| --- | --- |
| `src/wss.ts` | Add timeout + callback cleanup to `_send()`; validate image data and pass through `mimeType` in `callImage()` |
| `extension/main.js` | Return `mimeType: 'image/webp'` for viewport screenshots |


## Test plan

- [x] Capture a viewport screenshot and confirm the image renders correctly (now `image/webp`)
- [x] `npm run build` / typecheck passes