### PR TITLE
Fix zombie MCP server processes when Cursor/ClaudeCode exits on Windows.

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -96,13 +96,70 @@ mcp.connect(transport).then(() => {
     process.exit(1);
 });
 
-const close = () => {
-    mcp.close().finally(() => {
-        console.error('[MCP] Closed');
-        wss.close();
+let shuttingDown = false;
+
+const shutdown = async (reason: string) => {
+    if (shuttingDown) {
+        return;
+    }
+    shuttingDown = true;
+    console.error(`[MCP] Shutdown: ${reason}`);
+
+    const forceExit = setTimeout(() => {
+        console.error('[MCP] Force exit after timeout');
         process.exit(0);
-    });
+    }, 3000);
+    forceExit.unref();
+
+    try {
+        await mcp.close();
+    } catch (err) {
+        console.error('[MCP] close error', err);
+    }
+    try {
+        await wss.close();
+    } catch (err) {
+        console.error('[WSS] close error', err);
+    }
+    clearTimeout(forceExit);
+    process.stdin.destroy?.();
+    console.error('[MCP] Closed');
+    process.exit(0);
 };
+
+const isParentAlive = (parentPid: number) => {
+    try {
+        process.kill(parentPid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+// Stdin close/end is the most reliable cross-platform signal when the MCP client disconnects.
+// On Windows, SIGTERM is often not delivered when the parent IDE exits.
+if (!process.stdin.isTTY) {
+    process.stdin.resume();
+}
+process.stdin.on('end', () => shutdown('stdin end'));
+process.stdin.on('close', () => shutdown('stdin close'));
+process.stdin.on('error', () => shutdown('stdin error'));
+
+const onPipeError = (stream: string) => (err: { code?: string }) => {
+    if (err.code === 'EPIPE' || err.code === 'ECONNRESET') {
+        shutdown(`${stream} pipe broken`);
+    }
+};
+process.stdout?.on('error', onPipeError('stdout'));
+process.stderr?.on('error', onPipeError('stderr'));
+
+const parentPid = process.ppid;
+const parentWatchdog = setInterval(() => {
+    if (!isParentAlive(parentPid)) {
+        clearInterval(parentWatchdog);
+        shutdown('parent process exited');
+    }
+}, 2000);
 
 // Handle uncaught exceptions and unhandled rejections
 process.on('uncaughtException', (err) => {
@@ -118,19 +175,6 @@ process.on('exit', (code) => {
 });
 
 // Clean up on exit
-process.stdin.on('close', () => {
-    console.error('[process] stdin closed');
-    close();
-});
-process.on('SIGINT', () => {
-    console.error('[process] SIGINT');
-    close();
-});
-process.on('SIGTERM', () => {
-    console.error('[process] SIGTERM');
-    close();
-});
-process.on('SIGQUIT', () => {
-    console.error('[process] SIGQUIT');
-    close();
-});
+for (const signal of ['SIGINT', 'SIGTERM', 'SIGQUIT', 'SIGHUP'] as const) {
+    process.on(signal, () => shutdown(signal));
+}

--- a/src/wss.ts
+++ b/src/wss.ts
@@ -118,15 +118,21 @@ class WSS {
         }
     }
 
-    close() {
+    close(): Promise<void> {
         if (this._pingInterval) {
             clearInterval(this._pingInterval);
+            this._pingInterval = null;
         }
         if (this._socket) {
             this._socket.close(1000, 'FORCE');
+            this._socket = undefined;
         }
-        this._server.close();
-        console.error('[WSS] Closed');
+        return new Promise((resolve) => {
+            this._server.close(() => {
+                console.error('[WSS] Closed');
+                resolve();
+            });
+        });
     }
 }
 


### PR DESCRIPTION
Fixes orphaned Node.js processes that kept running after closing Cursor on Windows.

When the IDE exits, the MCP server child process was not always terminating. On Windows this is especially common because SIGTERM/SIGINT are often not delivered to child processes, and stdin close may never fire when the parent disconnects. The WebSocket server could also keep the Node event loop alive if shutdown did not wait for it to close.

This change adds layered shutdown handling so the server exits reliably when the MCP client disconnects:

stdin end / close / error — primary disconnect signal when the stdio pipe closes
stdout/stderr broken-pipe detection — handles EPIPE / ECONNRESET when the parent process dies
Parent process watchdog — polls process.ppid every 2 seconds and exits if the parent is gone (important on Windows)
Force-exit timeout — guarantees process termination if graceful cleanup hangs
process.stdin.destroy() — releases stdin references so the event loop can exit
Async WebSocket cleanup — WSS.close() now returns a Promise and waits for the server to fully close before exiting