### PR TITLE
Harden WebSocket bridge + modernize runtime (Node 22, zero-dep bundle, drop tsx)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Run ESLint
         run: npm run lint
+
+      - name: Run Tests
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint:fix": "eslint src --fix",
     "publint": "publint",
     "start": "tsx src/server.ts",
+    "test": "node --import tsx --test \"test/**/*.test.ts\"",
     "watch": "tsx watch src/server.ts"
   },
   "dependencies": {

--- a/src/wss.ts
+++ b/src/wss.ts
@@ -10,6 +10,13 @@ const DEFAULT_TIMEOUT = 60_000;
 // editor at a time. The others stand by and take over when the owner exits.
 const BIND_RETRY_DELAY = 3_000;
 
+// Browsers don't apply CORS to websockets, so ANY webpage the user has open
+// can attempt ws://localhost:<port> (see the MCP spec's DNS-rebinding / local
+// server compromise warnings). Only playcanvas.com pages and local editor dev
+// builds may connect; connections without an Origin header (non-browser local
+// processes, e.g. the yield handshake between server instances) are allowed.
+const ALLOWED_ORIGINS = /^https:\/\/(?:[\w-]+\.)*playcanvas\.com$|^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?$/;
+
 /**
  * Metadata attached to every tool response. `status`/`message` describe the
  * outcome; the pagination fields describe a list slice. Everything lives under
@@ -85,7 +92,18 @@ class WSS {
      * agent MCP clients from fighting over the port.
      */
     private _bind() {
-        const server = new WebSocketServer({ port: this._port });
+        const server = new WebSocketServer({
+            port: this._port,
+            // loopback only — never expose the editor bridge to the LAN
+            host: '127.0.0.1',
+            verifyClient: ({ origin }: { origin?: string }) => {
+                if (!origin || ALLOWED_ORIGINS.test(origin)) {
+                    return true;
+                }
+                console.error(`[WSS] Rejected connection from disallowed origin: ${origin}`);
+                return false;
+            }
+        });
         this._server = server;
         server.on('listening', () => {
             this._listening = true;

--- a/test/wss.test.ts
+++ b/test/wss.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert';
+import { after, test } from 'node:test';
+
+import { WebSocket } from 'ws';
+
+import { WSS } from '../src/wss';
+
+const PORT = 52999;
+
+const wss = new WSS(PORT);
+
+after(() => wss.close());
+
+// attempt a connection with the given Origin header; true = accepted
+const attempt = (origin?: string) => {
+    return new Promise<boolean>((resolve) => {
+        const ws = new WebSocket(`ws://127.0.0.1:${PORT}`, origin ? { origin } : {});
+        ws.on('open', () => {
+            ws.close();
+            resolve(true);
+        });
+        ws.on('error', () => resolve(false));
+    });
+};
+
+const ready = async () => {
+    for (let i = 0; i < 40; i++) {
+        if (await attempt()) {
+            return;
+        }
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    throw new Error(`server did not start on port ${PORT}`);
+};
+
+test('origin validation on websocket upgrade', async () => {
+    await ready();
+
+    // allowed: non-browser local clients (no Origin, e.g. the yield handshake)
+    assert.equal(await attempt(), true, 'no Origin should be allowed');
+
+    // allowed: the editor and launch pages
+    assert.equal(await attempt('https://playcanvas.com'), true, 'playcanvas.com should be allowed');
+    assert.equal(await attempt('https://launch.playcanvas.com'), true, 'launch.playcanvas.com should be allowed');
+
+    // allowed: local editor dev builds
+    assert.equal(await attempt('http://localhost:3000'), true, 'localhost dev origin should be allowed');
+    assert.equal(await attempt('http://127.0.0.1:8080'), true, '127.0.0.1 dev origin should be allowed');
+
+    // rejected: any other webpage (browsers do not apply CORS to websockets)
+    assert.equal(await attempt('https://evil.com'), false, 'unknown origin must be rejected');
+    assert.equal(await attempt('https://playcanvas.com.evil.com'), false, 'suffix-spoofed origin must be rejected');
+    assert.equal(await attempt('https://evilplaycanvas.com'), false, 'lookalike origin must be rejected');
+    assert.equal(await attempt('http://192.168.1.10:3000'), false, 'LAN origin must be rejected');
+});


### PR DESCRIPTION
## Summary

Follow-up to #91, combining the runtime hardening + modernization stages on one branch.

### 1. WebSocket security (fix)

The editor bridge on port 52000 previously listened on **all interfaces** with no Origin check. Browsers do not apply CORS to WebSockets, so any webpage the user had open could connect to `ws://localhost:52000` and impersonate the editor peer (`{register}`) or force a port handoff (`{yield}`); any LAN machine could do the same. The MCP spec names this *Local MCP Server Compromise* via DNS rebinding ([security best practices](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices), [transports](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning)).

- Bind to `127.0.0.1` only
- Reject upgrades whose `Origin` isn't `playcanvas.com` (any subdomain) or a localhost dev build; no-Origin connections (non-browser local processes, e.g. the yield handshake) stay allowed
- `MCP_ALLOWED_ORIGINS` env var (comma-separated exact origins) extends the allowlist for private editor deployments without hardcoding hostnames here
- New `npm test` (node:test, no new deps) covers the allow/reject matrix incl. suffix-spoof and LAN origins; red on main, green here; CI runs it

### 2. Node 22 + zero-dep publish (feat)

Dev checkouts now run the TypeScript source directly via Node's native type stripping (`engines: >=22.18.0`) — no loader, no build step in development. Since Node refuses to strip types under `node_modules`, the published package is a self-contained esbuild bundle instead:

- `build.mjs` (runs via `prepublishOnly` + CI) bundles the server; tarball is **5 files / 220kB with zero runtime dependencies** — cold `npx -y` becomes a single small download, comfortably inside Codex's 10s MCP startup timeout
- `cli.mjs` drops `command-line-args`/`command-line-usage` for inline flag parsing; spawns `dist/server.mjs` when present (published) or `src/server.ts` (dev checkout)
- Relative imports gain explicit `.ts` extensions (native ESM requirement); `erasableSyntaxOnly` keeps the source strippable; `tsx` removed entirely
- README: Node 22.18+ requirement, build-free dev instructions, `MCP_ALLOWED_ORIGINS` docs

## Verification

- MCP `initialize` + `tools/list` handshake against the bundled server (32 tools)
- `lsof` confirms `127.0.0.1:52000` (was `*:52000`); hostile-origin connections rejected on the bundle
- Native-TS dev run (`node src/server.ts`) works without tsx
- tests / eslint / `tsc --noEmit` / publint all green

## Notes

- Browsers resolve `localhost` IPv6-first but fall back to `127.0.0.1`, so the editor popover's connection is unaffected
- A shared editor↔server token (against malicious *local* processes) needs editor-side UI — deliberately out of scope