### PR TITLE
ci: align release script and workflows with eslint-config format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,34 +1,68 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
+    build:
+        name: Build
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v7
 
-      - name: Set up Node.js 24.x
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org/"
+            - name: Set up Node.js
+              uses: actions/setup-node@v7
+              with:
+                  node-version: 24.x
+                  cache: 'npm'
+                  registry-url: 'https://registry.npmjs.org/'
 
-      - name: Install Dependencies
-        run: npm ci
+            - name: Install Dependencies
+              run: npm ci
 
-      - name: Run ESLint
-        run: npm run lint
+            - name: Build PlayCanvas Editor MCP Server
+              run: npm run build
 
-      - name: Run Build
-        run: npm run build
+    lint:
+        name: Lint
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v7
 
-      - name: Run Tests
-        run: npm test
+            - name: Set up Node.js
+              uses: actions/setup-node@v7
+              with:
+                  node-version: 24.x
+                  cache: 'npm'
+                  registry-url: 'https://registry.npmjs.org/'
+
+            - name: Install Dependencies
+              run: npm ci
+
+            - name: Run ESLint
+              run: npm run lint
+
+    test:
+        name: Test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v7
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v7
+              with:
+                  node-version: 24.x
+                  cache: 'npm'
+                  registry-url: 'https://registry.npmjs.org/'
+
+            - name: Install Dependencies
+              run: npm ci
+
+            - name: Run Tests
+              run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,42 +1,59 @@
 name: Publish
 
 on:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+    push:
+        tags:
+            - 'v[0-9]+.[0-9]+.[0-9]+'
+            - 'v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
 
 jobs:
-  publish:
-    name: Publish
-    runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'playcanvas' }}
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
+    publish:
+        name: Publish
+        runs-on: ubuntu-latest
+        if: ${{ github.repository_owner == 'playcanvas' }}
+        permissions:
+            contents: write
+            id-token: write
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v7
 
-      - name: Set up Node.js 24.x
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org/"
+            - name: Set up Node.js
+              uses: actions/setup-node@v7
+              with:
+                  node-version: 24.x
+                  cache: 'npm'
+                  registry-url: 'https://registry.npmjs.org/'
 
-      - name: Install Dependencies
-        run: npm ci
+            - name: Parse tag name
+              run: |
+                  TAG_NAME=${GITHUB_REF#refs/tags/}
+                  echo "TAG=${TAG_NAME}" >> $GITHUB_ENV
 
-      - name: Run Publint
-        run: npm run publint
+            - name: Install Dependencies
+              run: npm ci
 
-      - name: Publish to npm
-        run: npm publish --provenance
+            - name: Build PlayCanvas Editor MCP Server
+              run: npm run build
+              env:
+                  NODE_ENV: production
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Run Publint
+              run: npm run publint
+
+            - name: Publish to npm
+              run: |
+                  if [[ "${{ env.TAG }}" =~ "beta" ]]; then
+                    tag=beta
+                  else
+                    tag=latest
+                  fi
+                  npm publish --tag $tag --provenance
+
+            - name: Create GitHub Release
+              uses: softprops/action-gh-release@v3
+              with:
+                  generate_release_notes: true
+                  prerelease: ${{ contains(github.ref, 'beta') }}
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release.sh
+++ b/release.sh
@@ -1,26 +1,27 @@
 #!/bin/bash -e
 
 TYPE=$1
+PRE_ID_PREVIEW="beta"
 
-if [ -z "$TYPE" ]; then
-    echo "Usage: $0 <type>"
-    echo "type: major, minor, patch"
+if [[ ! " major minor patch premajor prerelease " =~ " $TYPE " ]]; then
+    echo "Usage: $0 (major|minor|patch|premajor|prerelease)"
     exit 1
 fi
 
+# Fetch all remote tags
+git fetch --tags
+
+# Calculate the next version
+npm version $TYPE --preid=$PRE_ID_PREVIEW --no-git-tag-version >> /dev/null
+NEXT_VERSION=$(npm pkg get version | sed 's/"//g')
+git reset --hard >> /dev/null
+
 # Confirm release
-read -p "Are you sure you want to release a new version? (y/N): " -r
+read -p "About to release 'v$NEXT_VERSION'. Continue? (y/N) " -r
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     echo "Release cancelled."
     exit 1
 fi
 
 # Tag release
-npm version $TYPE
-
-# Publish to npm
-npm publish
-
-# Push to GitHub
-git push origin main
-git push --tags
+npm version $TYPE --preid=$PRE_ID_PREVIEW


### PR DESCRIPTION
Aligns the release script and CI/publish workflows with the format used by sibling packages (e.g. `@playcanvas/eslint-config`).

## Why
`release.sh` predated the tag-triggered publish workflow and did a local `npm publish`, which double-published (a non-provenance local publish, then a CI publish that fails because the version already exists). The publish workflow also ran `publint` before building, validating a `dist/` that doesn't exist after `npm ci`.

## Changes
- **`release.sh`** — matches eslint-config: `npm version` dry-run to preview the next version, confirm, then create the commit + tag. Stops at tag creation — no local publish, no push (the push, and thus the publish trigger, stays manual). Adds `beta` prerelease support (`premajor`/`prerelease` + `--preid=beta`).
- **`.github/workflows/publish.yml`** — builds before `publint`; triggers on `vX.Y.Z` and `vX.Y.Z-beta.N`; publishes with `--provenance` to the `beta` or `latest` dist-tag; `@v7` actions, `gh-release@v3`, 4-space house indentation.
- **`.github/workflows/ci.yml`** — split into `build` / `lint` / `test` jobs; `@v7` actions; 4-space indentation.

## Note
The CI `test` job does not build first (unlike eslint-config, whose tests load built entry points), because `test/wss.test.ts` imports `../src/wss.ts` directly via Node's native TS.
