### PR TITLE
feat: add tools for asset read, scene/project management, and editor control

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,9 @@ import pkg from '../package.json' with { type: 'json' };
 import { register as registerAsset } from './tools/asset.ts';
 import { register as registerAssetMaterial } from './tools/assets/material.ts';
 import { register as registerAssetScript } from './tools/assets/script.ts';
+import { register as registerEditor } from './tools/editor.ts';
 import { register as registerEntity } from './tools/entity.ts';
+import { register as registerProject } from './tools/project.ts';
 import { register as registerRuntime } from './tools/runtime.ts';
 import { register as registerScene } from './tools/scene.ts';
 import { register as registerStore } from './tools/store.ts';
@@ -159,9 +161,11 @@ registerAsset(mcp, wss);
 registerAssetMaterial(mcp, wss);
 registerAssetScript(mcp, wss);
 registerScene(mcp, wss);
+registerProject(mcp, wss);
 registerStore(mcp, wss);
 registerViewport(mcp, wss);
 registerRuntime(mcp, wss);
+registerEditor(mcp, wss);
 
 // Start receiving messages on stdin and sending messages on stdout
 const transport = new StdioServerTransport();

--- a/src/tools/assets/script.ts
+++ b/src/tools/assets/script.ts
@@ -5,6 +5,27 @@ import type { WSS } from '../../wss.ts';
 
 export const register = (server: McpServer, wss: WSS) => {
     server.registerTool(
+        'get_asset_text',
+        {
+            description: [
+                'Read the full text contents of a text-based asset (script, text, json, css, html, or shader), returned as text.',
+                'When NOT to use: to read a script\'s declared name or attribute definitions (use script_parse), to read binary assets like textures or models, or to list assets (use list_assets).'
+            ].join(' '),
+            annotations: {
+                title: 'Get Asset Text',
+                readOnlyHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                assetId: z.number().describe('Asset id of a text-based asset (script, text, json, css, html, shader)')
+            }
+        },
+        ({ assetId }) => {
+            return wss.call('assets:file:text:get', assetId);
+        }
+    );
+
+    server.registerTool(
         'set_script_text',
         {
             description: [

--- a/src/tools/editor.ts
+++ b/src/tools/editor.ts
@@ -1,0 +1,134 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { WSS } from '../wss.ts';
+
+const SelectionIdSchema = z.union([z.number(), z.string()]);
+
+export const register = (server: McpServer, wss: WSS) => {
+    server.registerTool(
+        'undo',
+        {
+            description: [
+                'Undo the last edit in the editor. Returns whether anything was undone plus the resulting { canUndo, canRedo } state.',
+                'Use this to roll back a change you just made. When NOT to use: to switch scenes (use load_scene).'
+            ].join(' '),
+            annotations: {
+                title: 'Undo',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false
+            }
+        },
+        () => {
+            return wss.call('history:undo');
+        }
+    );
+
+    server.registerTool(
+        'redo',
+        {
+            description: [
+                'Redo the last undone edit in the editor. Returns whether anything was redone plus the resulting { canUndo, canRedo } state.',
+                'When NOT to use: to repeat an arbitrary action (redo only re-applies an edit that was just undone).'
+            ].join(' '),
+            annotations: {
+                title: 'Redo',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false
+            }
+        },
+        () => {
+            return wss.call('history:redo');
+        }
+    );
+
+    server.registerTool(
+        'get_selection',
+        {
+            description: [
+                'Read the editor\'s current selection. Returns { type: "entity" | "asset" | null, ids: [...] }.',
+                'Entity ids are resource_ids (strings); asset ids are numbers. When NOT to use: to list all entities/assets (use list_entities/list_assets).'
+            ].join(' '),
+            annotations: {
+                title: 'Get Selection',
+                readOnlyHint: true,
+                openWorldHint: false
+            }
+        },
+        () => {
+            return wss.call('selection:get');
+        }
+    );
+
+    server.registerTool(
+        'set_selection',
+        {
+            description: [
+                'Replace the editor\'s selection with the given entities or assets. Selecting shows them in the inspector and highlights them in the viewport/tree.',
+                'Pass type "entity" (ids are resource_ids) or "asset" (ids are numbers). An empty ids array clears the selection.',
+                'When NOT to use: to modify the selected items (use modify_entities) or to frame them in the viewport (use focus_viewport).'
+            ].join(' '),
+            annotations: {
+                title: 'Set Selection',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                type: z.enum(['entity', 'asset']).describe('What kind of items the ids refer to'),
+                ids: z.array(SelectionIdSchema).describe('Ids to select (entity resource_ids or asset ids); empty clears the selection')
+            }
+        },
+        ({ type, ids }) => {
+            return wss.call('selection:set', type, ids);
+        }
+    );
+
+    server.registerTool(
+        'clear_selection',
+        {
+            description: 'Clear the editor\'s current selection.',
+            annotations: {
+                title: 'Clear Selection',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            }
+        },
+        () => {
+            return wss.call('selection:clear');
+        }
+    );
+
+    server.registerTool(
+        'set_transform_gizmo',
+        {
+            description: [
+                'Set the viewport transform gizmo: mode (translate/rotate/scale/resize), coordinate space (world/local), and/or snapping.',
+                'Only the provided fields change. Returns the resulting { mode, space }.',
+                'When NOT to use: to actually move/rotate/scale an entity (use modify_entities on its transform).'
+            ].join(' '),
+            annotations: {
+                title: 'Set Transform Gizmo',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                mode: z.enum(['translate', 'rotate', 'scale', 'resize']).optional().describe('Transform gizmo mode'),
+                space: z.enum(['world', 'local']).optional().describe('Coordinate space the gizmo operates in'),
+                snap: z.boolean().optional().describe('Enable or disable grid/angle snapping')
+            }
+        },
+        ({ mode, space, snap }) => {
+            return wss.call('gizmo:state:set', { mode, space, snap });
+        }
+    );
+};

--- a/src/tools/entity.ts
+++ b/src/tools/entity.ts
@@ -297,4 +297,47 @@ export const register = (server: McpServer, wss: WSS) => {
             return wss.call('entities:script:attach', id, scriptName);
         }
     );
+
+    server.registerTool(
+        'search_entities',
+        {
+            description: [
+                'Fuzzy-search entities by name and return the best matches ranked by relevance (each as a compact summary).',
+                'Use this to find an entity when you only know part of its name. When NOT to use: to filter by component or tag (use list_entities) or to find entities using a script (use find_entities_by_script).'
+            ].join(' '),
+            annotations: {
+                title: 'Search Entities',
+                readOnlyHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                query: z.string().describe('Name (or partial name) to fuzzy-match against'),
+                limit: z.number().int().min(1).optional().describe('Max results to return (default: all matches)')
+            }
+        },
+        ({ query, limit }) => {
+            return wss.call('entities:search', query, limit);
+        }
+    );
+
+    server.registerTool(
+        'find_entities_by_script',
+        {
+            description: [
+                'List the entities whose script component uses a given (registered) script name. Returns compact entity summaries.',
+                'When NOT to use: to search entities by name (use search_entities) or to read a script\'s source (use get_asset_text).'
+            ].join(' '),
+            annotations: {
+                title: 'Find Entities By Script',
+                readOnlyHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                script: z.string().describe('Registered script name to look up')
+            }
+        },
+        ({ script }) => {
+            return wss.call('entities:byScript', script);
+        }
+    );
 };

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -1,0 +1,48 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { WSS } from '../wss.ts';
+
+export const register = (server: McpServer, wss: WSS) => {
+    server.registerTool(
+        'modify_project_settings',
+        {
+            description: [
+                'Modify project-wide settings such as physics engine, rendering device (WebGL2/WebGPU), layers, loading screen, script loading order, input, and resolution.',
+                'Pass a partial object of setting path/value pairs (nested objects or dot-paths, e.g. { enableWebGpu: true, "layers.0.name": "World" }); only the provided fields change. Returns the full resulting project settings snapshot.',
+                'When NOT to use: to change per-scene settings like fog or gravity (use modify_scene_settings) or a single entity (use modify_entities).'
+            ].join(' '),
+            annotations: {
+                title: 'Modify Project Settings',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                settings: z.record(z.unknown()).describe('Partial project settings to change (path/value pairs); only provided fields are modified')
+            }
+        },
+        ({ settings }) => {
+            return wss.call('project:settings:modify', settings);
+        }
+    );
+
+    server.registerTool(
+        'query_project_settings',
+        {
+            description: [
+                'Read the current project-wide settings (physics, rendering device, layers, loading screen, script loading order, input, resolution). Returns the full settings object.',
+                'When NOT to use: to change settings (use modify_project_settings) or to read per-scene settings (use query_scene_settings).'
+            ].join(' '),
+            annotations: {
+                title: 'Query Project Settings',
+                readOnlyHint: true,
+                openWorldHint: false
+            }
+        },
+        () => {
+            return wss.call('project:settings:query');
+        }
+    );
+};

--- a/src/tools/scene.ts
+++ b/src/tools/scene.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
 
 import type { WSS } from '../wss.ts';
 
@@ -44,6 +45,141 @@ export const register = (server: McpServer, wss: WSS) => {
         },
         () => {
             return wss.call('scene:settings:query');
+        }
+    );
+
+    server.registerTool(
+        'list_scenes',
+        {
+            description: [
+                'List the scenes in the current project/branch. Returns scene records including id, uniqueId and name.',
+                'Use uniqueId with load_scene to switch scenes, and id with get_scene / duplicate_scene / delete_scene.',
+                'When NOT to use: to list assets (use list_assets).'
+            ].join(' '),
+            annotations: {
+                title: 'List Scenes',
+                readOnlyHint: true,
+                openWorldHint: false
+            }
+        },
+        () => {
+            return wss.call('scenes:list');
+        }
+    );
+
+    server.registerTool(
+        'get_scene',
+        {
+            description: [
+                'Get a single scene by its id (not uniqueId). Returns the full scene record.',
+                'When NOT to use: to load/switch to a scene in the editor (use load_scene) or to list scenes (use list_scenes).'
+            ].join(' '),
+            annotations: {
+                title: 'Get Scene',
+                readOnlyHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                id: z.union([z.number(), z.string()]).describe('Scene id (the "id" field from list_scenes, not uniqueId)')
+            }
+        },
+        ({ id }) => {
+            return wss.call('scenes:get', id);
+        }
+    );
+
+    server.registerTool(
+        'load_scene',
+        {
+            description: [
+                'Load (switch the editor to) a scene by its uniqueId. This unloads the current scene and opens the target one.',
+                'Loading is asynchronous: the tool returns once the switch has been requested, before it completes.',
+                'When NOT to use: to read a scene without switching (use get_scene) or to create a new scene (use create_scene).'
+            ].join(' '),
+            annotations: {
+                title: 'Load Scene',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                uniqueId: z.union([z.number(), z.string()]).describe('Scene uniqueId (the "uniqueId" field from list_scenes, not id)')
+            }
+        },
+        ({ uniqueId }) => {
+            return wss.call('scene:load', uniqueId);
+        }
+    );
+
+    server.registerTool(
+        'create_scene',
+        {
+            description: [
+                'Create a new empty scene in the current project/branch. Returns the created scene record.',
+                'This does not switch to the new scene; call load_scene with its uniqueId to open it.',
+                'When NOT to use: to copy an existing scene (use duplicate_scene).'
+            ].join(' '),
+            annotations: {
+                title: 'Create Scene',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false
+            },
+            inputSchema: {
+                name: z.string().optional().describe('Name for the new scene (optional)')
+            }
+        },
+        ({ name }) => {
+            return wss.call('scenes:new', name);
+        }
+    );
+
+    server.registerTool(
+        'duplicate_scene',
+        {
+            description: [
+                'Duplicate an existing scene by its id, giving the copy a new name. Returns the created scene record.',
+                'When NOT to use: to create an empty scene (use create_scene).'
+            ].join(' '),
+            annotations: {
+                title: 'Duplicate Scene',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false
+            },
+            inputSchema: {
+                id: z.union([z.number(), z.string()]).describe('Scene id to duplicate (the "id" field from list_scenes)'),
+                name: z.string().describe('Name for the duplicated scene')
+            }
+        },
+        ({ id, name }) => {
+            return wss.call('scenes:duplicate', id, name);
+        }
+    );
+
+    server.registerTool(
+        'delete_scene',
+        {
+            description: [
+                'Permanently delete a scene by its id. This is destructive and cannot be undone.',
+                'When NOT to use: to switch away from a scene without deleting it (use load_scene).'
+            ].join(' '),
+            annotations: {
+                title: 'Delete Scene',
+                readOnlyHint: false,
+                destructiveHint: true,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                id: z.union([z.number(), z.string()]).describe('Scene id to delete (the "id" field from list_scenes)')
+            }
+        },
+        ({ id }) => {
+            return wss.call('scenes:delete', id);
         }
     );
 };

--- a/src/tools/viewport.ts
+++ b/src/tools/viewport.ts
@@ -50,4 +50,28 @@ export const register = (server: McpServer, wss: WSS) => {
             return wss.call('viewport:focus', ids, { view, yaw, pitch });
         }
     );
+
+    server.registerTool(
+        'focus_camera',
+        {
+            description: [
+                'Aim the current editor camera to look at a world-space point from a given distance. Useful for framing an exact location before capture_viewport.',
+                'When NOT to use: to frame specific entities (use focus_viewport) or to move an in-scene camera entity (use modify_entities on its transform).'
+            ].join(' '),
+            annotations: {
+                title: 'Focus Camera',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                point: z.array(z.number()).length(3).describe('World-space point [x, y, z] to look at'),
+                distance: z.number().describe('Distance from the point at which to place the camera')
+            }
+        },
+        ({ point, distance }) => {
+            return wss.call('camera:focus:point', point, distance);
+        }
+    );
 };


### PR DESCRIPTION
Adds MCP tools that expand what a client can drive in the PlayCanvas Editor beyond content authoring. Pairs with the editor-side handlers in **playcanvas/editor#2155** — each tool below forwards to a matching `mcp.method` there (the tool times out without it, so these should land together).

## New tools

**Reading**
- `get_asset_text` — read any text-based asset's source (script/text/json/css/html/shader). Generalizes the earlier script-only read.

**Project & scene management** (`src/tools/project.ts`, `src/tools/scene.ts`)
- `query_project_settings` / `modify_project_settings`
- `list_scenes` / `get_scene` / `load_scene` / `create_scene` / `duplicate_scene` / `delete_scene`

**Editing session** (`src/tools/editor.ts`)
- `undo` / `redo`
- `get_selection` / `set_selection` / `clear_selection`
- `set_transform_gizmo` (mode / space / snap)

**Viewport** (`src/tools/viewport.ts`)
- `focus_camera` — aim the current camera at a world-space point

**Search** (`src/tools/entity.ts`)
- `search_entities` — fuzzy-search by name
- `find_entities_by_script`

## Notes
- Every new `wss.call('<message>', …)` has a matching `mcp.method('<message>', …)` in the editor PR (1:1).
- `npm run lint` and `npm run build` pass clean.
- Destructive tools (`delete_scene`) and outward-facing state changes are annotated accordingly.
- Not yet exercised end-to-end against a live editor; a manual smoke test is recommended once both PRs are together.
