### PR TITLE
feat: expand editor tool coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,23 @@ You can now issue commands from your MCP client.
 
 ## Available Tools
 
-| Category | Tools                                                                                                                                                                                         |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Entity   | `list_entities`, `resolve_entities`, `create_entities`, `delete_entities`, `duplicate_entities`, `modify_entities`, `reparent_entity`, `add_components`, `remove_components`, `add_script_component_script`, `attach_script` |
-| Asset    | `list_assets`, `create_assets`, `delete_assets`, `instantiate_template_assets`, `set_script_text`, `script_parse`, `set_material_diffuse`, `set_material_properties`                          |
-| Scene    | `query_scene_settings`, `modify_scene_settings`                                                                                                                                               |
-| Store    | `store_search`, `store_get`, `store_download`                                                                                                                                                 |
-| Viewport | `capture_viewport`, `focus_viewport`                                                                                                                                                          |
-| Runtime  | `launch_start`, `launch_stop`, `capture_runtime`, `read_runtime_logs`, `query_runtime_state`, `inject_input`                                                                                  |
-| VCS      | `vcs_status`, `list_branches`, `create_branch`, `switch_branch`, `close_branch`, `open_branch`, `delete_branch`, `list_checkpoints`, `create_checkpoint`, `get_checkpoint`, `restore_checkpoint`, `hard_reset_checkpoint`, `start_merge`, `get_merge`, `resolve_conflicts`, `get_conflict_file`, `apply_merge`, `cancel_merge`, `diff_checkpoints` |
+All tools act on the project open in the connected Editor. The server does not discover, select, create, delete, transfer, or administer projects, and project IDs are not tool inputs.
+
+| Category | Tools |
+| --- | --- |
+| Entity | `list_entities`, `resolve_entities`, `search_entities`, `find_entities_by_script`, `create_entities`, `modify_entities`, `duplicate_entities`, `reparent_entity`, `delete_entities`, `add_components`, `remove_components` |
+| Scripts | `get_asset_text`, `set_asset_text`, `set_script_text`, `script_parse`, `add_script_component_script`, `attach_script`, `add_entity_scripts`, `remove_entity_scripts`, `move_entity_script` |
+| Assets | `list_assets`, `create_assets`, `upload_assets`, `modify_assets`, `move_assets`, `duplicate_assets`, `replace_asset`, `reimport_assets`, `download_asset`, `delete_assets`, `set_material_diffuse`, `set_material_properties` |
+| Templates | `instantiate_template_assets`, `get_template_overrides`, `apply_template_overrides`, `revert_template_overrides`, `unlink_template_instances` |
+| Animation | `get_anim_state_graph`, `modify_anim_state_graph`, `get_animation_events`, `modify_animation_events` |
+| Processing | `bake_lightmaps`, `unwrap_model_asset`, `cancel_model_unwrap`, `convert_texture_asset`, `create_texture_atlas`, `create_cubemap_from_texture`, `modify_sprite_asset`, `modify_bundle_asset` |
+| Scene | `list_scenes`, `get_scene`, `load_scene`, `create_scene`, `duplicate_scene`, `delete_scene`, `query_scene_settings`, `modify_scene_settings`, `query_project_settings`, `modify_project_settings` |
+| Viewport | `query_viewport_state`, `set_viewport_state`, `query_viewport_visibility`, `set_viewport_visibility`, `capture_viewport`, `focus_viewport`, `focus_camera` |
+| Editor | `get_selection`, `set_selection`, `clear_selection`, `set_transform_gizmo`, `undo`, `redo` |
+| Builds | `list_builds`, `get_build`, `create_build`, `download_build`, `delete_build` |
+| Store | `store_search`, `store_get`, `store_download` |
+| Runtime | `launch_start`, `launch_stop`, `capture_runtime`, `read_runtime_logs`, `query_runtime_state`, `inject_input` |
+| VCS | `vcs_status`, `list_branches`, `create_branch`, `switch_branch`, `close_branch`, `open_branch`, `delete_branch`, `list_checkpoints`, `create_checkpoint`, `get_checkpoint`, `restore_checkpoint`, `hard_reset_checkpoint`, `start_merge`, `get_merge`, `resolve_conflicts`, `get_conflict_file`, `apply_merge`, `cancel_merge`, `diff_checkpoints` |
 
 The Runtime tools drive a real Launch instance (the Editor's Launch button) so an agent can verify that a scene actually *runs*: screenshot the running app, read its console output, query live entity state, and inject keyboard/mouse/touch input. Allow pop-ups for the editor origin so `launch_start` can open the launch window — it reuses your existing PlayCanvas login session.
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,11 +7,15 @@ import { WebSocket } from 'ws';
 
 import pkg from '../package.json' with { type: 'json' };
 
+import { register as registerAnimation } from './tools/animation.ts';
+import { register as registerAnimStateGraph } from './tools/animstategraph.ts';
 import { register as registerAsset } from './tools/asset.ts';
 import { register as registerAssetMaterial } from './tools/assets/material.ts';
 import { register as registerAssetScript } from './tools/assets/script.ts';
+import { register as registerBuild } from './tools/build.ts';
 import { register as registerEditor } from './tools/editor.ts';
 import { register as registerEntity } from './tools/entity.ts';
+import { register as registerProcessing } from './tools/processing.ts';
 import { register as registerProject } from './tools/project.ts';
 import { register as registerRuntime } from './tools/runtime.ts';
 import { register as registerScene } from './tools/scene.ts';
@@ -161,6 +165,10 @@ registerEntity(mcp, wss);
 registerAsset(mcp, wss);
 registerAssetMaterial(mcp, wss);
 registerAssetScript(mcp, wss);
+registerAnimation(mcp, wss);
+registerAnimStateGraph(mcp, wss);
+registerProcessing(mcp, wss);
+registerBuild(mcp, wss);
 registerScene(mcp, wss);
 registerProject(mcp, wss);
 registerStore(mcp, wss);

--- a/src/tools/animation.ts
+++ b/src/tools/animation.ts
@@ -7,7 +7,7 @@ const IdSchema = z.number().int().min(0).max(Number.MAX_SAFE_INTEGER);
 const EventPropertiesSchema = z
     .object({
         name: z.string().min(1).optional(),
-        time: z.number().finite().min(0).optional(),
+        time: z.number().finite().min(0).max(1).optional(),
         number: z.number().finite().nullable().optional(),
         string: z.string().optional()
     })
@@ -20,7 +20,7 @@ export const AnimationEventOperationSchema = z.discriminatedUnion('kind', [
             kind: z.literal('event.add'),
             id: IdSchema.optional(),
             name: z.string().min(1),
-            time: z.number().finite().min(0),
+            time: z.number().finite().min(0).max(1),
             properties: z
                 .object({
                     number: z.number().finite().nullable().optional(),
@@ -62,7 +62,7 @@ export const register = (server: McpServer, wss: WSS) => {
         'modify_animation_events',
         {
             description:
-                'Add, update, or remove GLB animation events as one undoable transaction. Event ids remain stable and generated ids are returned.',
+                'Add, update, or remove GLB animation events as one undoable transaction. Times are normalized from 0 to 1. Event ids remain stable and generated ids are returned.',
             annotations: {
                 title: 'Modify Animation Events',
                 readOnlyHint: false,

--- a/src/tools/animation.ts
+++ b/src/tools/animation.ts
@@ -1,0 +1,80 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { WSS } from '../wss.ts';
+
+const IdSchema = z.number().int().min(0).max(Number.MAX_SAFE_INTEGER);
+const EventPropertiesSchema = z
+    .object({
+        name: z.string().min(1).optional(),
+        time: z.number().finite().min(0).optional(),
+        number: z.number().finite().nullable().optional(),
+        string: z.string().optional()
+    })
+    .strict()
+    .refine((value) => Object.values(value).some((item) => item !== undefined), 'Provide at least one event property.');
+
+export const AnimationEventOperationSchema = z.discriminatedUnion('kind', [
+    z
+        .object({
+            kind: z.literal('event.add'),
+            id: IdSchema.optional(),
+            name: z.string().min(1),
+            time: z.number().finite().min(0),
+            properties: z
+                .object({
+                    number: z.number().finite().nullable().optional(),
+                    string: z.string().optional()
+                })
+                .strict()
+                .optional()
+        })
+        .strict(),
+    z
+        .object({
+            kind: z.literal('event.update'),
+            id: IdSchema,
+            properties: EventPropertiesSchema
+        })
+        .strict(),
+    z.object({ kind: z.literal('event.remove'), id: IdSchema }).strict()
+]);
+
+export const register = (server: McpServer, wss: WSS) => {
+    server.registerTool(
+        'get_animation_events',
+        {
+            description:
+                'Get the stable-id event map for a GLB animation asset, including time and optional number/string payloads.',
+            annotations: {
+                title: 'Get Animation Events',
+                readOnlyHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                assetId: IdSchema.describe('GLB animation asset id')
+            }
+        },
+        ({ assetId }) => wss.call('animation:events:get', assetId)
+    );
+
+    server.registerTool(
+        'modify_animation_events',
+        {
+            description:
+                'Add, update, or remove GLB animation events as one undoable transaction. Event ids remain stable and generated ids are returned.',
+            annotations: {
+                title: 'Modify Animation Events',
+                readOnlyHint: false,
+                destructiveHint: true,
+                idempotentHint: false,
+                openWorldHint: false
+            },
+            inputSchema: {
+                assetId: IdSchema.describe('GLB animation asset id'),
+                operations: z.array(AnimationEventOperationSchema).min(1).max(100)
+            }
+        },
+        ({ assetId, operations }) => wss.call('animation:events:modify', assetId, operations)
+    );
+};

--- a/src/tools/animstategraph.ts
+++ b/src/tools/animstategraph.ts
@@ -1,0 +1,245 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { WSS } from '../wss.ts';
+
+const IdSchema = z.number().int().min(0).max(Number.MAX_SAFE_INTEGER);
+const NameSchema = z
+    .string()
+    .min(1)
+    .regex(/^[A-Za-z0-9 _-]+$/);
+const ParameterTypeSchema = z.enum(['INTEGER', 'FLOAT', 'BOOLEAN', 'TRIGGER']);
+const PredicateSchema = z.enum([
+    'EQUAL_TO',
+    'NOT_EQUAL_TO',
+    'LESS_THAN',
+    'LESS_THAN_EQUAL_TO',
+    'GREATER_THAN',
+    'GREATER_THAN_EQUAL_TO'
+]);
+const InterruptionSchema = z.enum([
+    'NONE',
+    'NEXT_STATE',
+    'PREV_STATE',
+    'NEXT_STATE_PREV_STATE',
+    'PREV_STATE_NEXT_STATE'
+]);
+const ValueSchema = z.union([z.number().finite(), z.boolean()]);
+const fields = (value: Record<string, unknown>) => Object.values(value).some((item) => item !== undefined);
+
+const LayerPropertiesSchema = z
+    .object({
+        name: NameSchema.optional(),
+        blendType: z.enum(['OVERWRITE', 'ADDITIVE']).optional(),
+        weight: z.number().min(0).max(1).optional(),
+        defaultStateId: IdSchema.optional()
+    })
+    .strict()
+    .refine(fields, 'Provide at least one layer property.');
+
+const StatePropertiesSchema = z
+    .object({
+        name: NameSchema.optional(),
+        speed: z.number().finite().optional(),
+        loop: z.boolean().optional(),
+        posX: z.number().finite().optional(),
+        posY: z.number().finite().optional()
+    })
+    .strict()
+    .refine(fields, 'Provide at least one state property.');
+
+const TransitionPropertiesSchema = z
+    .object({
+        exitTime: z.number().finite().min(0).optional(),
+        interruptionSource: InterruptionSchema.optional(),
+        priority: z.number().int().min(0).optional(),
+        time: z.number().finite().min(0).optional(),
+        transitionOffset: z.number().finite().min(0).max(1).optional()
+    })
+    .strict()
+    .refine(fields, 'Provide at least one transition property.');
+
+const ConditionPropertiesSchema = z
+    .object({
+        parameterName: NameSchema.optional(),
+        predicate: PredicateSchema.optional(),
+        value: ValueSchema.optional()
+    })
+    .strict()
+    .refine(fields, 'Provide at least one condition property.');
+
+const ParameterPropertiesSchema = z
+    .object({
+        name: NameSchema.optional(),
+        type: ParameterTypeSchema.optional(),
+        value: ValueSchema.optional()
+    })
+    .strict()
+    .refine(fields, 'Provide at least one parameter property.');
+
+const AddConditionPropertiesSchema = z
+    .object({
+        parameterName: NameSchema,
+        predicate: PredicateSchema.default('EQUAL_TO'),
+        value: ValueSchema
+    })
+    .strict();
+
+export const AnimStateGraphOperationSchema = z.discriminatedUnion('kind', [
+    z
+        .object({
+            kind: z.literal('layer.add'),
+            id: IdSchema.optional(),
+            name: NameSchema.optional(),
+            properties: z
+                .object({
+                    blendType: z.enum(['OVERWRITE', 'ADDITIVE']).optional(),
+                    weight: z.number().min(0).max(1).optional()
+                })
+                .strict()
+                .optional()
+        })
+        .strict(),
+    z
+        .object({
+            kind: z.literal('layer.update'),
+            id: IdSchema,
+            properties: LayerPropertiesSchema
+        })
+        .strict(),
+    z.object({ kind: z.literal('layer.remove'), id: IdSchema }).strict(),
+    z.object({ kind: z.literal('layer.move'), id: IdSchema, index: IdSchema }).strict(),
+    z
+        .object({
+            kind: z.literal('state.add'),
+            layerId: IdSchema,
+            id: IdSchema.optional(),
+            name: NameSchema,
+            properties: z
+                .object({
+                    speed: z.number().finite().optional(),
+                    loop: z.boolean().optional(),
+                    posX: z.number().finite().optional(),
+                    posY: z.number().finite().optional()
+                })
+                .strict()
+                .optional()
+        })
+        .strict(),
+    z
+        .object({
+            kind: z.literal('state.update'),
+            id: IdSchema,
+            properties: StatePropertiesSchema
+        })
+        .strict(),
+    z.object({ kind: z.literal('state.remove'), id: IdSchema }).strict(),
+    z
+        .object({
+            kind: z.literal('transition.add'),
+            layerId: IdSchema,
+            id: IdSchema.optional(),
+            from: IdSchema,
+            to: IdSchema,
+            properties: TransitionPropertiesSchema.optional()
+        })
+        .strict(),
+    z
+        .object({
+            kind: z.literal('transition.update'),
+            id: IdSchema,
+            properties: TransitionPropertiesSchema
+        })
+        .strict(),
+    z.object({ kind: z.literal('transition.remove'), id: IdSchema }).strict(),
+    z
+        .object({
+            kind: z.literal('transition.move'),
+            id: IdSchema,
+            index: IdSchema
+        })
+        .strict(),
+    z
+        .object({
+            kind: z.literal('condition.add'),
+            transitionId: IdSchema,
+            id: IdSchema.optional(),
+            properties: AddConditionPropertiesSchema
+        })
+        .strict(),
+    z
+        .object({
+            kind: z.literal('condition.update'),
+            transitionId: IdSchema,
+            id: IdSchema,
+            properties: ConditionPropertiesSchema
+        })
+        .strict(),
+    z
+        .object({
+            kind: z.literal('condition.remove'),
+            transitionId: IdSchema,
+            id: IdSchema
+        })
+        .strict(),
+    z
+        .object({
+            kind: z.literal('parameter.add'),
+            id: IdSchema.optional(),
+            name: NameSchema,
+            type: ParameterTypeSchema,
+            value: ValueSchema
+        })
+        .strict(),
+    z
+        .object({
+            kind: z.literal('parameter.update'),
+            id: IdSchema,
+            properties: ParameterPropertiesSchema
+        })
+        .strict(),
+    z.object({ kind: z.literal('parameter.remove'), id: IdSchema }).strict()
+]);
+
+export const register = (server: McpServer, wss: WSS) => {
+    server.registerTool(
+        'get_anim_state_graph',
+        {
+            description:
+                'Get the complete structural data for an anim state graph asset, including layers, states, transitions, conditions, and parameters.',
+            annotations: {
+                title: 'Get Anim State Graph',
+                readOnlyHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                assetId: IdSchema.describe('Anim state graph asset id')
+            }
+        },
+        ({ assetId }) => wss.call('animstategraph:get', assetId)
+    );
+
+    server.registerTool(
+        'modify_anim_state_graph',
+        {
+            description: [
+                'Apply a validated batch of structural operations to an anim state graph as one undoable transaction.',
+                'Add operations may omit id to allocate one; generated ids and the resulting graph are returned.',
+                'State deletion also deletes attached transitions. Parameter deletion is rejected while conditions use it.',
+                'Use layer.update defaultStateId to change a layer default before removing its old default state.'
+            ].join(' '),
+            annotations: {
+                title: 'Modify Anim State Graph',
+                readOnlyHint: false,
+                destructiveHint: true,
+                idempotentHint: false,
+                openWorldHint: false
+            },
+            inputSchema: {
+                assetId: IdSchema.describe('Anim state graph asset id'),
+                operations: z.array(AnimStateGraphOperationSchema).min(1).max(100)
+            }
+        },
+        ({ assetId, operations }) => wss.call('animstategraph:modify', assetId, operations)
+    );
+};

--- a/src/tools/asset.ts
+++ b/src/tools/asset.ts
@@ -39,7 +39,7 @@ export const register = (server: McpServer, wss: WSS) => {
             description: [
                 'Create one or more native data/text assets. Imported binary assets use upload_assets.',
                 'Each asset is { type, options }; options vary by type (e.g. material takes data, script takes filename/text, template takes an entity id).',
-                'Returns succeeded and failed entries so network-backed batches never hide partial results.',
+                'Successful batches return the existing asset-summary array. Failed batches retain error status and expose succeeded and failed entries in response metadata.',
                 'When NOT to use: to add an existing asset to an entity (use add_components/modify_entities) or to change a material\'s look after creation (use set_material_properties).'
             ].join(' '),
             annotations: {

--- a/src/tools/asset.ts
+++ b/src/tools/asset.ts
@@ -1,19 +1,45 @@
+import { readFile, stat, writeFile } from 'node:fs/promises';
+import { basename, resolve } from 'node:path';
+
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 import type { WSS } from '../wss.ts';
 
-import { CssCreateSchema, FolderCreateSchema, HtmlCreateSchema, MaterialCreateSchema, ScriptCreateSchema, ShaderCreateSchema, TemplateCreateSchema, TextCreateSchema } from './schema/asset.ts';
-import { AssetIdSchema } from './schema/common.ts';
+import {
+    AnimStateGraphCreateSchema,
+    BundleCreateSchema,
+    CssCreateSchema,
+    CubemapCreateSchema,
+    FolderCreateSchema,
+    HtmlCreateSchema,
+    I18nCreateSchema,
+    JsonCreateSchema,
+    MaterialCreateSchema,
+    ScriptCreateSchema,
+    ShaderCreateSchema,
+    SpriteCreateSchema,
+    TemplateCreateSchema,
+    TextCreateSchema
+} from './schema/asset.ts';
+import { AssetIdSchema, EntityIdSchema } from './schema/common.ts';
+
+// ponytail: base64 keeps one transport; add streaming if 20 mib imports are common
+const MAX_FILE_BYTES = 20 * 1024 * 1024;
+const AssetOverrideSchema = z.object({
+    resource_id: EntityIdSchema,
+    override_type: z.string().min(1),
+    path: z.string().optional()
+}).passthrough();
 
 export const register = (server: McpServer, wss: WSS) => {
     server.registerTool(
         'create_assets',
         {
             description: [
-                'Create one or more project assets: material, script, template, text, html, css, shader, or folder.',
+                'Create one or more native data/text assets. Imported binary assets use upload_assets.',
                 'Each asset is { type, options }; options vary by type (e.g. material takes data, script takes filename/text, template takes an entity id).',
-                'Returns the created asset summaries (id, name, type, folder) inline.',
+                'Returns succeeded and failed entries so network-backed batches never hide partial results.',
                 'When NOT to use: to add an existing asset to an entity (use add_components/modify_entities) or to change a material\'s look after creation (use set_material_properties).'
             ].join(' '),
             annotations: {
@@ -26,12 +52,18 @@ export const register = (server: McpServer, wss: WSS) => {
             inputSchema: {
                 assets: z.array(
                     z.union([
+                        AnimStateGraphCreateSchema,
+                        BundleCreateSchema,
                         CssCreateSchema,
+                        CubemapCreateSchema,
                         FolderCreateSchema,
                         HtmlCreateSchema,
+                        I18nCreateSchema,
+                        JsonCreateSchema,
                         MaterialCreateSchema,
                         ScriptCreateSchema,
                         ShaderCreateSchema,
+                        SpriteCreateSchema,
                         TemplateCreateSchema,
                         TextCreateSchema
                     ])
@@ -60,7 +92,7 @@ export const register = (server: McpServer, wss: WSS) => {
             },
             inputSchema: {
                 full: z.boolean().optional().describe('Return full asset JSON instead of the compact summary (much larger)'),
-                type: z.enum(['css', 'cubemap', 'folder', 'font', 'html', 'json', 'material', 'render', 'script', 'shader', 'template', 'text', 'texture']).optional().describe('Filter by asset type'),
+                type: z.enum(['animation', 'animstategraph', 'audio', 'binary', 'bundle', 'container', 'css', 'cubemap', 'folder', 'font', 'gsplat', 'html', 'json', 'material', 'model', 'render', 'scene', 'script', 'shader', 'sprite', 'template', 'text', 'texture', 'textureatlas', 'wasm']).optional().describe('Filter by asset type'),
                 name: z.string().optional().describe('Filter by name (case-insensitive contains)'),
                 tag: z.string().optional().describe('Filter by tag'),
                 limit: z.number().int().min(1).max(500).optional().describe('Max assets to return (default 50)'),
@@ -111,11 +143,223 @@ export const register = (server: McpServer, wss: WSS) => {
                 openWorldHint: false
             },
             inputSchema: {
-                ids: z.array(AssetIdSchema).nonempty().describe('Template asset ids to instantiate')
+                ids: z.array(AssetIdSchema).nonempty().describe('Template asset ids to instantiate'),
+                parentId: EntityIdSchema.optional().describe('Parent entity resource_id; defaults to the scene root'),
+                index: z.number().int().min(0).optional().describe('Insertion index under the parent')
             }
         },
-        ({ ids }) => {
-            return wss.call('assets:instantiate', ids);
+        ({ ids, parentId, index }) => {
+            return wss.call('templates:instantiate', { assetIds: ids, parentId, index });
         }
+    );
+
+    server.registerTool(
+        'upload_assets',
+        {
+            description: `Upload local files into the designated project. Files are limited to ${MAX_FILE_BYTES / 1024 / 1024} MiB each; the result separates succeeded and failed entries.`,
+            annotations: {
+                title: 'Upload Assets',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false
+            },
+            inputSchema: {
+                assets: z.array(z.object({
+                    path: z.string().min(1).describe('Local file path'),
+                    type: z.enum(['animation', 'audio', 'binary', 'css', 'font', 'gsplat', 'html', 'json', 'scene', 'script', 'shader', 'text', 'texture', 'textureatlas', 'wasm']).describe('PlayCanvas import type; use scene for model source files such as GLB or FBX'),
+                    folder: AssetIdSchema.optional(),
+                    name: z.string().optional(),
+                    tags: z.array(z.string()).optional(),
+                    data: z.record(z.any()).optional(),
+                    preload: z.boolean().optional(),
+                    mime: z.string().optional(),
+                    settings: z.record(z.any()).optional().describe('Texture or scene import settings')
+                })).nonempty()
+            }
+        },
+        async ({ assets }) => {
+            const [error, payload] = await Promise.resolve().then(async () => {
+                const files = await Promise.all(assets.map(async (asset) => {
+                    const path = resolve(asset.path);
+                    const info = await stat(path);
+                    if (!info.isFile()) {
+                        throw new Error(`Not a file: ${path}`);
+                    }
+                    if (info.size > MAX_FILE_BYTES) {
+                        throw new Error(`${path} exceeds the ${MAX_FILE_BYTES / 1024 / 1024} MiB upload limit.`);
+                    }
+                    const filename = basename(path);
+                    return { ...asset, path, filename, name: asset.name || filename };
+                }));
+                return Promise.all(files.map(async ({ path, ...asset }) => ({
+                    ...asset,
+                    base64: await readFile(path).then((bytes) => {
+                        if (bytes.length > MAX_FILE_BYTES) {
+                            throw new Error(`${path} exceeds the ${MAX_FILE_BYTES / 1024 / 1024} MiB upload limit.`);
+                        }
+                        return bytes.toString('base64');
+                    })
+                })));
+            }).then((data) => [null, data] as const, (err) => [err, null] as const);
+            if (error) {
+                return wss.fail('assets:upload', error instanceof Error ? error.message : String(error));
+            }
+            return wss.call('assets:upload', payload);
+        }
+    );
+
+    server.registerTool(
+        'modify_assets',
+        {
+            description: 'Edit asset name, tags, preload, or data paths. Array operations are supported under data.*. Anim state graph structure and animation events require their dedicated mutation tools.',
+            annotations: {
+                title: 'Modify Assets',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false
+            },
+            inputSchema: {
+                edits: z.array(z.union([
+                    z.object({ id: AssetIdSchema, path: z.string().min(1), op: z.literal('set').optional(), value: z.any() }),
+                    z.object({ id: AssetIdSchema, path: z.string().min(1), op: z.literal('unset') }),
+                    z.object({ id: AssetIdSchema, path: z.string().min(1), op: z.literal('insert'), value: z.any(), index: z.number().int().min(0).optional() }),
+                    z.object({ id: AssetIdSchema, path: z.string().min(1), op: z.literal('remove'), index: z.number().int().min(0) }),
+                    z.object({ id: AssetIdSchema, path: z.string().min(1), op: z.literal('move'), index: z.number().int().min(0), to: z.number().int().min(0) })
+                ])).nonempty()
+            }
+        },
+        ({ edits }) => wss.call('assets:modify', edits)
+    );
+
+    server.registerTool(
+        'move_assets',
+        {
+            description: 'Move assets to a folder in the designated project and wait until their paths update. Omit folderId to move them to the root.',
+            annotations: { title: 'Move Assets', readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            inputSchema: {
+                ids: z.array(AssetIdSchema).nonempty(),
+                folderId: AssetIdSchema.nullable().optional()
+            }
+        },
+        ({ ids, folderId }) => wss.call('assets:move', ids, folderId)
+    );
+
+    server.registerTool(
+        'duplicate_assets',
+        {
+            description: 'Queue asset duplication in the current folders. The editor confirms the accepted source ids; list_assets to resolve the generated copies.',
+            annotations: { title: 'Duplicate Assets', readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+            inputSchema: { ids: z.array(AssetIdSchema).nonempty() }
+        },
+        ({ ids }) => wss.call('assets:duplicate', ids)
+    );
+
+    server.registerTool(
+        'replace_asset',
+        {
+            description: 'Replace references to one asset with another asset.',
+            annotations: { title: 'Replace Asset References', readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            inputSchema: { assetId: AssetIdSchema, replacementId: AssetIdSchema }
+        },
+        ({ assetId, replacementId }) => wss.call('assets:replace', assetId, replacementId)
+    );
+
+    server.registerTool(
+        'reimport_assets',
+        {
+            description: 'Re-run the import pipeline for existing source assets and return succeeded and failed entries.',
+            annotations: { title: 'Reimport Assets', readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
+            inputSchema: {
+                ids: z.array(AssetIdSchema).nonempty(),
+                settings: z.record(z.any()).optional()
+            }
+        },
+        ({ ids, settings }) => wss.call('assets:reimport', ids, settings)
+    );
+
+    server.registerTool(
+        'download_asset',
+        {
+            description: `Download an asset to a local file. Downloads are limited to ${MAX_FILE_BYTES / 1024 / 1024} MiB and never overwrite unless overwrite=true.`,
+            annotations: { title: 'Download Asset', readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+            inputSchema: {
+                assetId: AssetIdSchema,
+                path: z.string().min(1).describe('Local output path'),
+                overwrite: z.boolean().optional()
+            }
+        },
+        async ({ assetId, path, overwrite }) => {
+            const output = resolve(path);
+            if (!overwrite && await stat(output).then(() => true, () => false)) {
+                return wss.fail('assets:file:get', `File already exists: ${output}. Set overwrite=true to replace it.`);
+            }
+            const raw = await wss.raw('assets:file:get', assetId);
+            if (raw.error) {
+                return wss.fail('assets:file:get', raw.error);
+            }
+            const data = raw.data as { base64?: string; filename?: string; mime?: string };
+            if (
+                typeof data?.base64 !== 'string' ||
+                data.base64.length > Math.ceil(MAX_FILE_BYTES / 3) * 4 ||
+                data.base64.length % 4 !== 0 ||
+                !/^[a-z\d+/]*={0,2}$/i.test(data.base64)
+            ) {
+                return wss.fail('assets:file:get', 'Editor returned invalid or oversized asset data.');
+            }
+            const bytes = Buffer.from(data.base64, 'base64');
+            if (bytes.length > MAX_FILE_BYTES) {
+                return wss.fail('assets:file:get', `Asset exceeds the ${MAX_FILE_BYTES / 1024 / 1024} MiB download limit.`);
+            }
+            const error = await writeFile(output, bytes, { flag: overwrite ? 'w' : 'wx' }).then(
+                () => null,
+                (err) => (err instanceof Error ? err : new Error(String(err)))
+            );
+            if (error) {
+                return wss.fail('assets:file:get', error.message);
+            }
+            return wss.ok('assets:file:get', { path: output, filename: data.filename, mime: data.mime, bytes: bytes.length });
+        }
+    );
+
+    server.registerTool(
+        'get_template_overrides',
+        {
+            description: 'Read the current apply/revert override records for a template instance.',
+            annotations: { title: 'Get Template Overrides', readOnlyHint: true, openWorldHint: false },
+            inputSchema: { entityId: EntityIdSchema }
+        },
+        (options) => wss.call('templates:overrides:get', options)
+    );
+
+    server.registerTool(
+        'apply_template_overrides',
+        {
+            description: 'Apply all overrides from a template instance, or only the supplied override records.',
+            annotations: { title: 'Apply Template Overrides', readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+            inputSchema: { entityId: EntityIdSchema, overrides: z.array(AssetOverrideSchema).nonempty().optional() }
+        },
+        (options) => wss.call('templates:apply', options)
+    );
+
+    server.registerTool(
+        'revert_template_overrides',
+        {
+            description: 'Revert all overrides on a template instance, or only the supplied override records.',
+            annotations: { title: 'Revert Template Overrides', readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
+            inputSchema: { entityId: EntityIdSchema, overrides: z.array(AssetOverrideSchema).nonempty().optional() }
+        },
+        (options) => wss.call('templates:revert', options)
+    );
+
+    server.registerTool(
+        'unlink_template_instances',
+        {
+            description: 'Unlink template instances while keeping their current entity data.',
+            annotations: { title: 'Unlink Template Instances', readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+            inputSchema: { entityIds: z.array(EntityIdSchema).nonempty() }
+        },
+        (options) => wss.call('templates:unlink', options)
     );
 };

--- a/src/tools/assets/script.ts
+++ b/src/tools/assets/script.ts
@@ -26,6 +26,25 @@ export const register = (server: McpServer, wss: WSS) => {
     );
 
     server.registerTool(
+        'set_asset_text',
+        {
+            description: 'Overwrite the full contents of a CSS, HTML, JSON, script, shader, or text asset.',
+            annotations: {
+                title: 'Set Asset Text',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                assetId: z.number().describe('Text-based asset id'),
+                text: z.string().describe('Full replacement contents')
+            }
+        },
+        ({ assetId, text }) => wss.call('assets:text:set', assetId, text)
+    );
+
+    server.registerTool(
         'set_script_text',
         {
             description: [
@@ -46,7 +65,7 @@ export const register = (server: McpServer, wss: WSS) => {
             }
         },
         ({ assetId, text }) => {
-            return wss.call('assets:script:text:set', assetId, text);
+            return wss.call('assets:text:set', assetId, text);
         }
     );
 

--- a/src/tools/build.ts
+++ b/src/tools/build.ts
@@ -1,0 +1,224 @@
+import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { WSS } from '../wss.ts';
+
+const BUILD_TIMEOUT_MS = 10 * 60_000;
+const POLL_MS = 2_000;
+const IdSchema = z.number().int().positive();
+
+type BuildStart = {
+    id?: number;
+    build_job_id?: number;
+    result?: { id?: number };
+};
+type Artifact = { type: string; url: string };
+type Build = { status?: string; message?: string; artifacts?: Artifact[] };
+
+const fields = {
+    name: z.string().min(1).max(1000),
+    sceneIds: z
+        .array(IdSchema)
+        .nonempty()
+        .describe('Scene ids in the designated project'),
+    primarySceneId: IdSchema.optional().describe(
+        'Primary scene; must also be in sceneIds'
+    ),
+    engineVersion: z
+        .string()
+        .optional()
+        .describe(
+            'Configured engine channel or exact available engine version'
+        ),
+    concatenate: z.boolean().optional(),
+    minify: z.boolean().optional(),
+    sourceMaps: z.boolean().optional(),
+    optimizeSceneFormat: z.boolean().optional()
+};
+
+const sleep = () => new Promise((resolve) => setTimeout(resolve, POLL_MS));
+const raw = (wss: WSS, name: string, ...args: unknown[]) =>
+    wss.raw(name, ...args).catch((err) => ({
+        data: undefined,
+        error: err instanceof Error ? err.message : String(err)
+    }));
+
+export const register = (server: McpServer, wss: WSS) => {
+    server.registerTool(
+        'list_builds',
+        {
+            description:
+                'List publish and download builds for the designated project, including durable job status and artifacts.',
+            annotations: {
+                title: 'List Builds',
+                readOnlyHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                limit: z.number().int().min(1).max(500).optional(),
+                cursor: z.string().regex(/^\d+$/).optional(),
+                type: z.enum(['publish', 'download']).optional(),
+                status: z.enum(['complete', 'running', 'error']).optional(),
+                format: z.enum(['playcanvas', 'static', 'npm']).optional(),
+                branch: z.string().optional(),
+                actor: z.string().optional()
+            }
+        },
+        ({ limit, cursor, ...filters }) =>
+            wss.call('builds:list', { limit, cursor, filters })
+    );
+
+    server.registerTool(
+        'get_build',
+        {
+            description:
+                'Get a publish or download build job by id from the designated project.',
+            annotations: {
+                title: 'Get Build',
+                readOnlyHint: true,
+                openWorldHint: false
+            },
+            inputSchema: { buildId: z.number().int().positive() }
+        },
+        ({ buildId }) => wss.call('builds:get', buildId)
+    );
+
+    server.registerTool(
+        'create_build',
+        {
+            description:
+                'Create a published PlayCanvas build for scenes in the designated project. Returns the created durable build job.',
+            annotations: {
+                title: 'Create Build',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false
+            },
+            inputSchema: {
+                ...fields,
+                description: z.string().max(10000).optional(),
+                version: z.string().max(20).optional(),
+                releaseNotes: z.string().max(10000).optional()
+            }
+        },
+        (options) => wss.call('builds:create', options)
+    );
+
+    server.registerTool(
+        'download_build',
+        {
+            description:
+                'Create a static or NPM download build, wait for its artifact, and save the archive to an explicit local path. Existing files are not overwritten unless overwrite=true.',
+            annotations: {
+                title: 'Download Build',
+                readOnlyHint: false,
+                destructiveHint: true,
+                idempotentHint: false,
+                openWorldHint: true
+            },
+            inputSchema: {
+                ...fields,
+                format: z.enum(['static', 'npm']),
+                outputPath: z.string().min(1),
+                overwrite: z.boolean().optional()
+            }
+        },
+        async ({ outputPath, overwrite, ...options }) => {
+            const started = await raw(wss, 'builds:download', options);
+            if (started.error) {
+                return wss.fail('builds:download', started.error);
+            }
+            const data = started.data as BuildStart | undefined;
+            const id = data?.id ?? data?.build_job_id ?? data?.result?.id;
+            if (!id) {
+                return wss.fail(
+                    'builds:download',
+                    'The build started but returned no build id. Use list_builds to inspect its status.'
+                );
+            }
+            const deadline = Date.now() + BUILD_TIMEOUT_MS;
+            let build: Build | undefined;
+            while (Date.now() < deadline) {
+                const current = await raw(wss, 'builds:get', id);
+                if (current.error) {
+                    return wss.fail('builds:download', current.error);
+                }
+                build = current.data as Build;
+                if (build?.status === 'complete' || build?.status === 'error') {
+                    break;
+                }
+                await sleep();
+            }
+            if (build?.status === 'error') {
+                return wss.fail(
+                    'builds:download',
+                    build.message || `Build ${id} failed.`
+                );
+            }
+            if (build?.status !== 'complete') {
+                return wss.fail(
+                    'builds:download',
+                    `Build ${id} is still running after 10 minutes. Use get_build to inspect it.`
+                );
+            }
+            const artifact =
+                build.artifacts?.find((item) => item.type === 'download') ||
+                build.artifacts?.[0];
+            if (!artifact?.url) {
+                return wss.fail(
+                    'builds:download',
+                    `Build ${id} completed without a download artifact.`
+                );
+            }
+            const response = await fetch(artifact.url).catch((err) =>
+                err instanceof Error ? err : new Error(String(err))
+            );
+            if (response instanceof Error) {
+                return wss.fail('builds:download', response.message);
+            }
+            if (!response.ok) {
+                return wss.fail(
+                    'builds:download',
+                    `Artifact download failed (${response.status} ${response.statusText}).`
+                );
+            }
+            const path = resolve(outputPath);
+            const bytes = new Uint8Array(await response.arrayBuffer());
+            const error = await writeFile(path, bytes, {
+                flag: overwrite ? 'w' : 'wx'
+            }).then(
+                () => null,
+                (err) => (err instanceof Error ? err : new Error(String(err)))
+            );
+            if (error) {
+                return wss.fail('builds:download', error.message);
+            }
+            return wss.ok('builds:download', {
+                buildId: Number(id),
+                path,
+                bytes: bytes.byteLength
+            });
+        }
+    );
+
+    server.registerTool(
+        'delete_build',
+        {
+            description:
+                'Permanently delete a build job and its linked artifact from the designated project.',
+            annotations: {
+                title: 'Delete Build',
+                readOnlyHint: false,
+                destructiveHint: true,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: { buildId: z.number().int().positive() }
+        },
+        ({ buildId }) => wss.call('builds:delete', buildId)
+    );
+};

--- a/src/tools/build.ts
+++ b/src/tools/build.ts
@@ -1,5 +1,9 @@
-import { writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { link, rename, stat, unlink } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
@@ -186,13 +190,25 @@ export const register = (server: McpServer, wss: WSS) => {
                     `Artifact download failed (${response.status} ${response.statusText}).`
                 );
             }
+            if (!response.body) {
+                return wss.fail('builds:download', 'Artifact download returned no response body.');
+            }
             const path = resolve(outputPath);
-            const bytes = new Uint8Array(await response.arrayBuffer());
-            const error = await writeFile(path, bytes, {
-                flag: overwrite ? 'w' : 'wx'
-            }).then(
-                () => null,
-                (err) => (err instanceof Error ? err : new Error(String(err)))
+            const temp = `${path}.${randomUUID()}.tmp`;
+            const done = pipeline(Readable.fromWeb(response.body), createWriteStream(temp, { flags: 'wx' })).then(
+                async () => {
+                    const bytes = (await stat(temp)).size;
+                    await (overwrite ? rename(temp, path) : link(temp, path));
+                    await unlink(temp).catch(() => null);
+                    return bytes;
+                }
+            );
+            const [error, bytes] = await done.then(
+                (bytes) => [null, bytes] as const,
+                async (err) => {
+                    await unlink(temp).catch(() => null);
+                    return [err instanceof Error ? err : new Error(String(err)), 0] as const;
+                }
             );
             if (error) {
                 return wss.fail('builds:download', error.message);
@@ -200,7 +216,7 @@ export const register = (server: McpServer, wss: WSS) => {
             return wss.ok('builds:download', {
                 buildId: Number(id),
                 path,
-                bytes: bytes.byteLength
+                bytes
             });
         }
     );

--- a/src/tools/entity.ts
+++ b/src/tools/entity.ts
@@ -290,12 +290,79 @@ export const register = (server: McpServer, wss: WSS) => {
             },
             inputSchema: {
                 id: EntityIdSchema,
-                scriptName: z.string().describe('Registered script name to attach')
+                scriptName: z.string().describe('Registered script name to attach'),
+                attributes: z.record(z.any()).optional().describe('Initial script attribute values'),
+                index: z.number().int().min(0).optional().describe('Execution order index')
             }
         },
-        ({ id, scriptName }) => {
-            return wss.call('entities:script:attach', id, scriptName);
+        ({ id, scriptName, attributes, index }) => {
+            return wss.call('entities:scripts:add', {
+                entityIds: [id],
+                script: scriptName,
+                attributes,
+                index
+            });
         }
+    );
+
+    server.registerTool(
+        'add_entity_scripts',
+        {
+            description: 'Attach a parsed script to one or more entities, creating script components when needed.',
+            annotations: {
+                title: 'Add Entity Scripts',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                entityIds: z.array(EntityIdSchema).nonempty(),
+                script: z.string().min(1).describe('Registered script name'),
+                attributes: z.record(z.any()).optional(),
+                index: z.number().int().min(0).optional().describe('Execution order index')
+            }
+        },
+        (options) => wss.call('entities:scripts:add', options)
+    );
+
+    server.registerTool(
+        'remove_entity_scripts',
+        {
+            description: 'Remove a script from one or more entities.',
+            annotations: {
+                title: 'Remove Entity Scripts',
+                readOnlyHint: false,
+                destructiveHint: true,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                entityIds: z.array(EntityIdSchema).nonempty(),
+                script: z.string().min(1).describe('Registered script name')
+            }
+        },
+        (options) => wss.call('entities:scripts:remove', options)
+    );
+
+    server.registerTool(
+        'move_entity_script',
+        {
+            description: 'Move a script to a new execution-order index on an entity.',
+            annotations: {
+                title: 'Move Entity Script',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                entityId: EntityIdSchema,
+                script: z.string().min(1).describe('Registered script name'),
+                index: z.number().int().min(0).describe('New execution-order index')
+            }
+        },
+        (options) => wss.call('entities:scripts:move', options)
     );
 
     server.registerTool(

--- a/src/tools/processing.ts
+++ b/src/tools/processing.ts
@@ -1,0 +1,188 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { WSS } from '../wss.ts';
+
+import { EntityIdSchema } from './schema/common.ts';
+
+const IdSchema = z.number().int().positive();
+
+const FrameSchema = z.object({
+    name: z.string(),
+    rect: z.array(z.number()).length(4),
+    pivot: z.array(z.number()).length(2),
+    border: z.array(z.number()).length(4)
+});
+
+export const register = (server: McpServer, wss: WSS) => {
+    server.registerTool(
+        'bake_lightmaps',
+        {
+            description:
+                'Bake scene lightmaps, optionally limited to the given entities. Returns only after baking finishes and reports model assets missing UV1.',
+            annotations: {
+                title: 'Bake Lightmaps',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                entityIds: z
+                    .array(EntityIdSchema)
+                    .nonempty()
+                    .optional()
+                    .describe(
+                        'Lightmapped entity resource_ids; omit to bake all lightmapped entities'
+                    )
+            }
+        },
+        ({ entityIds }) => wss.call('lightmapper:bake', entityIds)
+    );
+
+    server.registerTool(
+        'unwrap_model_asset',
+        {
+            description:
+                "Generate UV1 data for a model asset using the editor's unwrap worker and update its source file.",
+            annotations: {
+                title: 'Unwrap Model Asset',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                id: IdSchema.describe('Model asset id'),
+                padding: z
+                    .number()
+                    .positive()
+                    .optional()
+                    .describe('UV island padding in pixels (default 2)')
+            }
+        },
+        ({ id, padding }) => wss.call('assets:model:unwrap', id, { padding })
+    );
+
+    server.registerTool(
+        'cancel_model_unwrap',
+        {
+            description: 'Cancel an in-progress UV1 unwrap for a model asset.',
+            annotations: {
+                title: 'Cancel Model Unwrap',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: { id: IdSchema.describe('Model asset id') }
+        },
+        ({ id }) => wss.call('assets:model:unwrap:cancel', id)
+    );
+
+    server.registerTool(
+        'convert_texture_asset',
+        {
+            description:
+                'Convert a texture source to a new AVIF, JPEG, PNG, or WebP texture asset.',
+            annotations: {
+                title: 'Convert Texture Asset',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false
+            },
+            inputSchema: {
+                id: IdSchema.describe('Source texture asset id'),
+                format: z.enum(['avif', 'jpeg', 'png', 'webp'])
+            }
+        },
+        ({ id, format }) => wss.call('assets:texture:convert', id, format)
+    );
+
+    server.registerTool(
+        'create_texture_atlas',
+        {
+            description:
+                'Duplicate a texture asset as an editable texture atlas and return the new asset.',
+            annotations: {
+                title: 'Create Texture Atlas',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false
+            },
+            inputSchema: { id: IdSchema.describe('Source texture asset id') }
+        },
+        ({ id }) => wss.call('assets:texture:toAtlas', id)
+    );
+
+    server.registerTool(
+        'create_cubemap_from_texture',
+        {
+            description:
+                'Convert an equirectangular texture to six face textures and a cubemap asset.',
+            annotations: {
+                title: 'Create Cubemap From Texture',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false
+            },
+            inputSchema: {
+                id: IdSchema.describe('Source equirectangular texture asset id')
+            }
+        },
+        ({ id }) => wss.call('assets:texture:toCubemap', id)
+    );
+
+    server.registerTool(
+        'modify_sprite_asset',
+        {
+            description:
+                'Modify sprite data (atlas, frame order, pixels per unit, render mode) or replace a texture atlas frame map in one undoable edit.',
+            annotations: {
+                title: 'Modify Sprite Asset',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                id: IdSchema.describe('Sprite or texture atlas asset id'),
+                props: z.object({
+                    pixelsPerUnit: z.number().positive().optional(),
+                    renderMode: z.number().int().min(0).max(1).optional(),
+                    frameKeys: z
+                        .array(z.union([z.string(), z.number()]))
+                        .optional(),
+                    textureAtlasAsset: IdSchema.optional(),
+                    frames: z.record(FrameSchema).optional()
+                })
+            }
+        },
+        ({ id, props }) => wss.call('assets:sprite:modify', id, props)
+    );
+
+    server.registerTool(
+        'modify_bundle_asset',
+        {
+            description:
+                'Add or remove project assets from a bundle. Returns accepted and rejected ids; invalid asset types and duplicates are rejected.',
+            annotations: {
+                title: 'Modify Bundle Asset',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                id: IdSchema.describe('Bundle asset id'),
+                add: z.array(IdSchema).optional(),
+                remove: z.array(IdSchema).optional()
+            }
+        },
+        ({ id, add, remove }) =>
+            wss.call('assets:bundle:modify', id, { add, remove })
+    );
+};

--- a/src/tools/processing.ts
+++ b/src/tools/processing.ts
@@ -14,6 +14,14 @@ const FrameSchema = z.object({
     border: z.array(z.number()).length(4)
 });
 
+const SpritePropsSchema = z.object({
+    pixelsPerUnit: z.number().positive().optional(),
+    renderMode: z.number().int().min(0).max(2).optional(),
+    frameKeys: z.array(z.union([z.string(), z.number()])).optional(),
+    textureAtlasAsset: IdSchema.optional(),
+    frames: z.record(FrameSchema).optional()
+});
+
 export const register = (server: McpServer, wss: WSS) => {
     server.registerTool(
         'bake_lightmaps',
@@ -150,15 +158,7 @@ export const register = (server: McpServer, wss: WSS) => {
             },
             inputSchema: {
                 id: IdSchema.describe('Sprite or texture atlas asset id'),
-                props: z.object({
-                    pixelsPerUnit: z.number().positive().optional(),
-                    renderMode: z.number().int().min(0).max(1).optional(),
-                    frameKeys: z
-                        .array(z.union([z.string(), z.number()]))
-                        .optional(),
-                    textureAtlasAsset: IdSchema.optional(),
-                    frames: z.record(FrameSchema).optional()
-                })
+                props: SpritePropsSchema
             }
         },
         ({ id, props }) => wss.call('assets:sprite:modify', id, props)
@@ -186,3 +186,5 @@ export const register = (server: McpServer, wss: WSS) => {
             wss.call('assets:bundle:modify', id, { add, remove })
     );
 };
+
+export { SpritePropsSchema };

--- a/src/tools/scene.ts
+++ b/src/tools/scene.ts
@@ -93,7 +93,7 @@ export const register = (server: McpServer, wss: WSS) => {
         {
             description: [
                 'Load (switch the editor to) a scene by its uniqueId. This unloads the current scene and opens the target one.',
-                'The tool returns only after the editor reports that the requested scene is active.',
+                'By default the tool returns after queuing the load. Set wait=true to return only after the requested scene is active.',
                 'When NOT to use: to read a scene without switching (use get_scene) or to create a new scene (use create_scene).'
             ].join(' '),
             annotations: {
@@ -104,10 +104,12 @@ export const register = (server: McpServer, wss: WSS) => {
                 openWorldHint: false
             },
             inputSchema: {
-                uniqueId: z.union([z.number(), z.string()]).describe('Scene uniqueId (the "uniqueId" field from list_scenes, not id)')
+                uniqueId: z.union([z.number(), z.string()]).describe('Scene uniqueId (the "uniqueId" field from list_scenes, not id)'),
+                wait: z.boolean().optional().describe('Wait until the editor reports the requested scene is active')
             }
         },
-        ({ uniqueId }) => wss.call('scene:load', uniqueId)
+        ({ uniqueId, wait }) =>
+            wait === undefined ? wss.call('scene:load', uniqueId) : wss.call('scene:load', uniqueId, { wait })
     );
 
     server.registerTool(

--- a/src/tools/scene.ts
+++ b/src/tools/scene.ts
@@ -93,7 +93,7 @@ export const register = (server: McpServer, wss: WSS) => {
         {
             description: [
                 'Load (switch the editor to) a scene by its uniqueId. This unloads the current scene and opens the target one.',
-                'Loading is asynchronous: the tool returns once the switch has been requested, before it completes.',
+                'The tool returns only after the editor reports that the requested scene is active.',
                 'When NOT to use: to read a scene without switching (use get_scene) or to create a new scene (use create_scene).'
             ].join(' '),
             annotations: {
@@ -107,9 +107,7 @@ export const register = (server: McpServer, wss: WSS) => {
                 uniqueId: z.union([z.number(), z.string()]).describe('Scene uniqueId (the "uniqueId" field from list_scenes, not id)')
             }
         },
-        ({ uniqueId }) => {
-            return wss.call('scene:load', uniqueId);
-        }
+        ({ uniqueId }) => wss.call('scene:load', uniqueId)
     );
 
     server.registerTool(

--- a/src/tools/schema/asset.ts
+++ b/src/tools/schema/asset.ts
@@ -359,7 +359,7 @@ export const SpriteCreateSchema = z.object({
         name: z.string().optional(),
         pixelsPerUnit: z.number().positive().optional(),
         preload: z.boolean().optional(),
-        renderMode: z.number().int().optional(),
+        renderMode: z.number().int().min(0).max(2).optional(),
         textureAtlas: AssetIdSchema.optional()
     }).optional()
 }).describe('Sprite asset');

--- a/src/tools/schema/asset.ts
+++ b/src/tools/schema/asset.ts
@@ -297,3 +297,69 @@ export const TextCreateSchema = z.object({
         text: z.string().optional()
     }).optional()
 }).describe('Text asset');
+
+export const AnimStateGraphCreateSchema = z.object({
+    type: z.literal('animstategraph'),
+    options: z.object({
+        folder: AssetIdSchema.optional(),
+        name: z.string().optional(),
+        preload: z.boolean().optional()
+    }).optional()
+}).describe('Animation state graph asset');
+
+export const BundleCreateSchema = z.object({
+    type: z.literal('bundle'),
+    options: z.object({
+        assets: z.array(AssetIdSchema).optional(),
+        folder: AssetIdSchema.optional(),
+        name: z.string().optional(),
+        preload: z.boolean().optional()
+    }).optional()
+}).describe('Bundle asset');
+
+export const CubemapCreateSchema = z.object({
+    type: z.literal('cubemap'),
+    options: z.object({
+        anisotropy: z.number().optional(),
+        folder: AssetIdSchema.optional(),
+        magFilter: z.number().int().optional(),
+        minFilter: z.number().int().optional(),
+        name: z.string().optional(),
+        preload: z.boolean().optional(),
+        textures: z.array(AssetIdSchema.nullable()).max(6).optional()
+    }).optional()
+}).describe('Cubemap asset');
+
+export const JsonCreateSchema = z.object({
+    type: z.literal('json'),
+    options: z.object({
+        folder: AssetIdSchema.optional(),
+        json: z.any().optional(),
+        name: z.string().optional(),
+        preload: z.boolean().optional(),
+        spaces: z.number().int().min(0).max(10).optional()
+    }).optional()
+}).describe('JSON asset');
+
+export const I18nCreateSchema = z.object({
+    type: z.literal('i18n'),
+    options: z.object({
+        folder: AssetIdSchema.optional(),
+        localizationData: z.record(z.any()).optional(),
+        name: z.string().optional(),
+        preload: z.boolean().optional()
+    }).optional()
+}).describe('Localization JSON asset');
+
+export const SpriteCreateSchema = z.object({
+    type: z.literal('sprite'),
+    options: z.object({
+        folder: AssetIdSchema.optional(),
+        frameKeys: z.array(z.union([z.string(), z.number()])).optional(),
+        name: z.string().optional(),
+        pixelsPerUnit: z.number().positive().optional(),
+        preload: z.boolean().optional(),
+        renderMode: z.number().int().optional(),
+        textureAtlas: AssetIdSchema.optional()
+    }).optional()
+}).describe('Sprite asset');

--- a/src/tools/viewport.ts
+++ b/src/tools/viewport.ts
@@ -7,6 +7,91 @@ import { EntityIdSchema } from './schema/common.ts';
 
 export const register = (server: McpServer, wss: WSS) => {
     server.registerTool(
+        'query_viewport_state',
+        {
+            description:
+                'Read the exact editor viewport camera and overlay state so it can be restored after visual inspection.',
+            annotations: {
+                title: 'Query Viewport State',
+                readOnlyHint: true,
+                openWorldHint: false
+            }
+        },
+        () => wss.call('viewport:state:get')
+    );
+
+    server.registerTool(
+        'set_viewport_state',
+        {
+            description:
+                "Set the editor viewport camera transform, projection, grid, bones, icon size, and expanded state. This controls the editor view, not an entity's persisted enabled state.",
+            annotations: {
+                title: 'Set Viewport State',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                cameraId: z
+                    .string()
+                    .optional()
+                    .describe(
+                        'Editor camera name (perspective/top/front/etc.) or camera entity resource_id'
+                    ),
+                position: z.array(z.number()).length(3).optional(),
+                rotation: z.array(z.number()).length(3).optional(),
+                projection: z.enum(['perspective', 'orthographic']).optional(),
+                orthoHeight: z.number().positive().optional(),
+                grid: z
+                    .object({
+                        divisions: z.number().int().min(0).optional(),
+                        size: z.number().min(0).optional()
+                    })
+                    .optional(),
+                bones: z.boolean().optional(),
+                iconSize: z.number().min(0).max(100).optional(),
+                expanded: z.boolean().optional()
+            }
+        },
+        (state) => wss.call('viewport:state:set', state)
+    );
+
+    server.registerTool(
+        'query_viewport_visibility',
+        {
+            description:
+                'List entities hidden only in the editor viewport. This does not read or change persisted entity enabled values.',
+            annotations: {
+                title: 'Query Viewport Visibility',
+                readOnlyHint: true,
+                openWorldHint: false
+            }
+        },
+        () => wss.call('viewport:visibility:get')
+    );
+
+    server.registerTool(
+        'set_viewport_visibility',
+        {
+            description:
+                'Hide or show entities only in the editor viewport without changing their persisted enabled values.',
+            annotations: {
+                title: 'Set Viewport Visibility',
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            },
+            inputSchema: {
+                ids: z.array(EntityIdSchema).nonempty(),
+                hidden: z.boolean()
+            }
+        },
+        ({ ids, hidden }) => wss.call('viewport:visibility:set', ids, hidden)
+    );
+
+    server.registerTool(
         'capture_viewport',
         {
             description: [

--- a/src/wss.ts
+++ b/src/wss.ts
@@ -4,6 +4,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 const PING_DELAY = 1000;
 
 const DEFAULT_TIMEOUT = 60_000;
+const PROTOCOL_VERSION = 1;
 
 // How often a standby instance retries binding the port. Multiple MCP clients
 // (agents) each run their own server; only one can own the port and talk to the
@@ -71,11 +72,14 @@ type RawResult = {
  * page that handles `runtime:*` methods (capture, logs, etc.).
  */
 type Role = 'editor' | 'runtime';
+type Capabilities = { protocolVersion?: number; methods?: Set<string> };
 
 class WSS {
     private _server!: WebSocketServer;
 
     private _sockets: Record<Role, WebSocket | undefined> = { editor: undefined, runtime: undefined };
+
+    private _capabilities: Record<Role, Capabilities | undefined> = { editor: undefined, runtime: undefined };
 
     private _callbacks = new Map<number, (res: RawResult) => void>();
 
@@ -144,17 +148,8 @@ class WSS {
         // lives for its whole life; it must NOT be re-added per disconnect (that
         // leaks listeners and double-handles messages).
         server.on('connection', (ws) => {
-            // Default new peers to the editor role so clients that don't send a
-            // `{ register }` handshake (e.g. older editor builds) still work.
-            // A `{ register }` message can reassign the socket — notably the
-            // launch page registers itself as 'runtime'.
             let role: Role = 'editor';
-            if (!this._sockets.editor) {
-                this._sockets.editor = ws;
-                this._editorGeneration++;
-                this._startPing();
-            }
-            console.error('[WSS] Peer connected (assumed editor; awaiting registration)');
+            console.error('[WSS] Peer connected; awaiting registration');
             ws.on('message', (data) => {
                 try {
                     const msg = JSON.parse(data.toString());
@@ -180,9 +175,14 @@ class WSS {
                         // Vacate the optimistic slot if we're switching roles.
                         if (newRole !== role && this._sockets[role] === ws) {
                             this._sockets[role] = undefined;
+                            this._capabilities[role] = undefined;
                         }
                         role = newRole;
                         this._sockets[role] = ws;
+                        this._capabilities[role] = {
+                            protocolVersion: Number.isInteger(msg.protocolVersion) ? msg.protocolVersion : undefined,
+                            methods: Array.isArray(msg.methods) ? new Set(msg.methods.filter((name: unknown) => typeof name === 'string')) : undefined
+                        };
                         console.error('[WSS] Registered', role);
                         if (role === 'editor') {
                             this._editorGeneration++;
@@ -203,6 +203,7 @@ class WSS {
             ws.on('close', () => {
                 if (this._sockets[role] === ws) {
                     this._sockets[role] = undefined;
+                    this._capabilities[role] = undefined;
                     console.error('[WSS] Disconnected', role);
                     if (role === 'editor' && this._pingInterval) {
                         clearInterval(this._pingInterval);
@@ -262,6 +263,7 @@ class WSS {
                 this._sockets[role]?.close();
             } catch { /* already closing */ }
             this._sockets[role] = undefined;
+            this._capabilities[role] = undefined;
         });
         try {
             this._server.close();
@@ -360,6 +362,15 @@ class WSS {
             }
             if (socket.readyState !== WebSocket.OPEN) {
                 reject(new Error(`${role === 'runtime' ? 'Runtime' : 'Editor'} socket not open. Reconnect (or re-run launch_start) and retry.`));
+                return;
+            }
+            const capabilities = this._capabilities[role];
+            if (capabilities?.protocolVersion !== PROTOCOL_VERSION || !capabilities.methods) {
+                reject(new Error(`${role === 'runtime' ? 'Runtime' : 'Editor'} does not advertise protocol ${PROTOCOL_VERSION} capabilities. Reload it with a compatible build and reconnect.`));
+                return;
+            }
+            if (!capabilities.methods.has(name)) {
+                reject(new Error(`${role === 'runtime' ? 'Runtime' : 'Editor'} does not support '${name}'. Reload it with a compatible build and reconnect.`));
                 return;
             }
             const timer = setTimeout(() => {
@@ -504,6 +515,7 @@ class WSS {
         (['editor', 'runtime'] as Role[]).forEach((role) => {
             this._sockets[role]?.close(1000, 'FORCE');
             this._sockets[role] = undefined;
+            this._capabilities[role] = undefined;
         });
         this._server.close();
         console.error('[WSS] Closed');

--- a/src/wss.ts
+++ b/src/wss.ts
@@ -149,7 +149,12 @@ class WSS {
         // leaks listeners and double-handles messages).
         server.on('connection', (ws) => {
             let role: Role = 'editor';
-            console.error('[WSS] Peer connected; awaiting registration');
+            if (!this._sockets.editor) {
+                this._sockets.editor = ws;
+                this._editorGeneration++;
+                this._startPing();
+            }
+            console.error('[WSS] Peer connected (assumed editor; awaiting registration)');
             ws.on('message', (data) => {
                 try {
                     const msg = JSON.parse(data.toString());
@@ -365,11 +370,14 @@ class WSS {
                 return;
             }
             const capabilities = this._capabilities[role];
-            if (capabilities?.protocolVersion !== PROTOCOL_VERSION || !capabilities.methods) {
-                reject(new Error(`${role === 'runtime' ? 'Runtime' : 'Editor'} does not advertise protocol ${PROTOCOL_VERSION} capabilities. Reload it with a compatible build and reconnect.`));
+            if (
+                capabilities?.protocolVersion !== undefined &&
+                capabilities.protocolVersion !== PROTOCOL_VERSION
+            ) {
+                reject(new Error(`${role === 'runtime' ? 'Runtime' : 'Editor'} advertises incompatible protocol ${capabilities.protocolVersion}; expected ${PROTOCOL_VERSION}. Reload it with a compatible build and reconnect.`));
                 return;
             }
-            if (!capabilities.methods.has(name)) {
+            if (capabilities?.methods && !capabilities.methods.has(name)) {
                 reject(new Error(`${role === 'runtime' ? 'Runtime' : 'Editor'} does not support '${name}'. Reload it with a compatible build and reconnect.`));
                 return;
             }

--- a/test/animation-tools.test.ts
+++ b/test/animation-tools.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { AnimationEventOperationSchema, register as registerAnimation } from '../src/tools/animation.ts';
+import { AnimStateGraphOperationSchema, register as registerGraph } from '../src/tools/animstategraph.ts';
+import type { WSS } from '../src/wss.ts';
+
+type Tool = (args: Record<string, unknown>) => unknown;
+
+const setup = () => {
+    const tools: Record<string, Tool> = {};
+    const calls: { name: string; args: unknown[] }[] = [];
+    const server = {
+        registerTool(name: string, _config: unknown, handler: Tool) {
+            tools[name] = handler;
+        }
+    };
+    const wss = {
+        call(name: string, ...args: unknown[]) {
+            calls.push({ name, args });
+            return { name, args };
+        }
+    };
+    registerGraph(server as unknown as McpServer, wss as unknown as WSS);
+    registerAnimation(server as unknown as McpServer, wss as unknown as WSS);
+    return { tools, calls };
+};
+
+test('animation authoring schemas enforce structural boundaries', () => {
+    assert.equal(
+        AnimStateGraphOperationSchema.safeParse({
+            kind: 'condition.add',
+            transitionId: 4,
+            properties: {
+                parameterName: 'Speed',
+                predicate: 'GREATER_THAN',
+                value: 0.1
+            }
+        }).success,
+        true
+    );
+    assert.equal(
+        AnimStateGraphOperationSchema.safeParse({
+            kind: 'condition.add',
+            transitionId: 4,
+            properties: { parameterName: 'Speed', predicate: 'INVALID', value: 0.1 }
+        }).success,
+        false
+    );
+    assert.equal(
+        AnimationEventOperationSchema.safeParse({
+            kind: 'event.add',
+            name: 'jumpOff',
+            time: -1
+        }).success,
+        false
+    );
+    assert.equal(
+        AnimStateGraphOperationSchema.safeParse({
+            kind: 'transition.update',
+            id: 4,
+            properties: { exitTime: -0.1 }
+        }).success,
+        false
+    );
+});
+
+test('animation authoring tools map to exact editor driver methods', () => {
+    const { tools, calls } = setup();
+    const graphOps = [{ kind: 'state.add', layerId: 0, id: 8, name: 'Jump' }];
+    const eventOps = [{ kind: 'event.update', id: 2, properties: { time: 0.3 } }];
+
+    tools.get_anim_state_graph({ assetId: 10 });
+    tools.modify_anim_state_graph({ assetId: 10, operations: graphOps });
+    tools.get_animation_events({ assetId: 20 });
+    tools.modify_animation_events({ assetId: 20, operations: eventOps });
+
+    assert.deepEqual(calls, [
+        { name: 'animstategraph:get', args: [10] },
+        { name: 'animstategraph:modify', args: [10, graphOps] },
+        { name: 'animation:events:get', args: [20] },
+        { name: 'animation:events:modify', args: [20, eventOps] }
+    ]);
+});

--- a/test/animation-tools.test.ts
+++ b/test/animation-tools.test.ts
@@ -58,6 +58,22 @@ test('animation authoring schemas enforce structural boundaries', () => {
         false
     );
     assert.equal(
+        AnimationEventOperationSchema.safeParse({
+            kind: 'event.add',
+            name: 'jumpOff',
+            time: 1.01
+        }).success,
+        false
+    );
+    assert.equal(
+        AnimationEventOperationSchema.safeParse({
+            kind: 'event.update',
+            id: 1,
+            properties: { time: 1.01 }
+        }).success,
+        false
+    );
+    assert.equal(
         AnimStateGraphOperationSchema.safeParse({
             kind: 'transition.update',
             id: 4,

--- a/test/asset-schema.test.ts
+++ b/test/asset-schema.test.ts
@@ -33,6 +33,8 @@ test('native asset create schemas accept their editor API inputs', () => {
         type: 'cubemap',
         options: { textures: [1, 2, 3, 4, 5, 6, 7] }
     }));
+    assert.equal(SpriteCreateSchema.safeParse({ type: 'sprite', options: { renderMode: 2 } }).success, true);
+    assert.equal(SpriteCreateSchema.safeParse({ type: 'sprite', options: { renderMode: 3 } }).success, false);
 });
 
 test('asset, template, text, and script tools route stable driver methods', () => {

--- a/test/asset-schema.test.ts
+++ b/test/asset-schema.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { register as registerAssets } from '../src/tools/asset.ts';
+import { register as registerScripts } from '../src/tools/assets/script.ts';
+import { register as registerEntities } from '../src/tools/entity.ts';
+import {
+    AnimStateGraphCreateSchema,
+    BundleCreateSchema,
+    CubemapCreateSchema,
+    I18nCreateSchema,
+    JsonCreateSchema,
+    SpriteCreateSchema
+} from '../src/tools/schema/asset.ts';
+import type { WSS } from '../src/wss.ts';
+
+type Handler = (args: Record<string, unknown>) => unknown;
+
+test('native asset create schemas accept their editor API inputs', () => {
+    const cases = [
+        [AnimStateGraphCreateSchema, { type: 'animstategraph', options: { name: 'Movement' } }],
+        [BundleCreateSchema, { type: 'bundle', options: { assets: [1, 2] } }],
+        [CubemapCreateSchema, { type: 'cubemap', options: { textures: [1, null, 2] } }],
+        [I18nCreateSchema, { type: 'i18n', options: { localizationData: { header: { version: 1 } } } }],
+        [JsonCreateSchema, { type: 'json', options: { json: { value: true } } }],
+        [SpriteCreateSchema, { type: 'sprite', options: { textureAtlas: 3, frameKeys: ['0'] } }]
+    ] as const;
+
+    cases.forEach(([schema, value]) => assert.deepEqual(schema.parse(value), value));
+    assert.throws(() => CubemapCreateSchema.parse({
+        type: 'cubemap',
+        options: { textures: [1, 2, 3, 4, 5, 6, 7] }
+    }));
+});
+
+test('asset, template, text, and script tools route stable driver methods', () => {
+    const tools: Record<string, Handler> = {};
+    const calls: { name: string; args: unknown[] }[] = [];
+    const server = {
+        registerTool(name: string, _config: unknown, handler: Handler) {
+            tools[name] = handler;
+        }
+    } as unknown as McpServer;
+    const wss = {
+        call(name: string, ...args: unknown[]) {
+            calls.push({ name, args });
+        }
+    } as unknown as WSS;
+
+    registerAssets(server, wss);
+    registerScripts(server, wss);
+    registerEntities(server, wss);
+
+    tools.instantiate_template_assets({ ids: [7], parentId: 'root', index: 2 });
+    assert.deepEqual(calls.at(-1), {
+        name: 'templates:instantiate',
+        args: [{ assetIds: [7], parentId: 'root', index: 2 }]
+    });
+
+    tools.modify_assets({ edits: [{ id: 7, path: 'name', value: 'Player' }] });
+    assert.deepEqual(calls.at(-1), {
+        name: 'assets:modify',
+        args: [[{ id: 7, path: 'name', value: 'Player' }]]
+    });
+
+    tools.set_asset_text({ assetId: 7, text: 'hello' });
+    assert.deepEqual(calls.at(-1), { name: 'assets:text:set', args: [7, 'hello'] });
+
+    tools.attach_script({ id: 'player', scriptName: 'controller', attributes: { speed: 2 }, index: 0 });
+    assert.deepEqual(calls.at(-1), {
+        name: 'entities:scripts:add',
+        args: [{ entityIds: ['player'], script: 'controller', attributes: { speed: 2 }, index: 0 }]
+    });
+
+    tools.get_template_overrides({ entityId: 'player' });
+    assert.deepEqual(calls.at(-1), {
+        name: 'templates:overrides:get',
+        args: [{ entityId: 'player' }]
+    });
+});

--- a/test/scene.test.ts
+++ b/test/scene.test.ts
@@ -19,7 +19,7 @@ const makeServer = () => {
     };
 };
 
-test('load_scene delegates readiness to the editor driver', async () => {
+test('load_scene preserves immediate loading and optionally waits for readiness', async () => {
     const calls: { name: string; args: unknown[] }[] = [];
     const wss = {
         call: async (name: string, ...args: unknown[]) => {
@@ -31,7 +31,11 @@ test('load_scene delegates readiness to the editor driver', async () => {
     register(server as unknown as McpServer, wss as unknown as WSS);
 
     const result = await server.tools.load_scene({ uniqueId: 'scene-2' });
+    await server.tools.load_scene({ uniqueId: 'scene-3', wait: true });
 
-    assert.deepEqual(calls, [{ name: 'scene:load', args: ['scene-2'] }]);
+    assert.deepEqual(calls, [
+        { name: 'scene:load', args: ['scene-2'] },
+        { name: 'scene:load', args: ['scene-3', { wait: true }] }
+    ]);
     assert.deepEqual(JSON.parse(result.content[0].text), { name: 'scene:load', data: { uniqueId: 'scene-2' } });
 });

--- a/test/scene.test.ts
+++ b/test/scene.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { register } from '../src/tools/scene.ts';
+import type { WSS } from '../src/wss.ts';
+
+type ToolResult = { content: { text: string }[]; isError?: boolean };
+type ToolHandler = (args: Record<string, unknown>) => ToolResult | Promise<ToolResult>;
+
+const makeServer = () => {
+    const tools: Record<string, ToolHandler> = {};
+    return {
+        tools,
+        registerTool(name: string, _cfg: unknown, handler: ToolHandler) {
+            tools[name] = handler;
+        }
+    };
+};
+
+test('load_scene delegates readiness to the editor driver', async () => {
+    const calls: { name: string; args: unknown[] }[] = [];
+    const wss = {
+        call: async (name: string, ...args: unknown[]) => {
+            calls.push({ name, args });
+            return { content: [{ text: JSON.stringify({ name, data: { uniqueId: args[0] } }) }] };
+        }
+    };
+    const server = makeServer();
+    register(server as unknown as McpServer, wss as unknown as WSS);
+
+    const result = await server.tools.load_scene({ uniqueId: 'scene-2' });
+
+    assert.deepEqual(calls, [{ name: 'scene:load', args: ['scene-2'] }]);
+    assert.deepEqual(JSON.parse(result.content[0].text), { name: 'scene:load', data: { uniqueId: 'scene-2' } });
+});

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert';
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -82,4 +85,59 @@ test('processing, viewport, and build tools route stable driver methods', async 
 test('sprite modification accepts tiled render mode', () => {
     assert.equal(SpritePropsSchema.safeParse({ renderMode: 2 }).success, true);
     assert.equal(SpritePropsSchema.safeParse({ renderMode: 3 }).success, false);
+});
+
+test('download_build streams artifacts without clobbering files', async (t) => {
+    const dir = await mkdtemp(join(tmpdir(), 'editor-mcp-'));
+    const path = join(dir, 'build.zip');
+    const tools: Record<string, Handler> = {};
+    let content = 'first';
+    t.after(() => rm(dir, { recursive: true, force: true }));
+    t.mock.method(globalThis, 'fetch', async () => new Response(content));
+    registerBuild(
+        {
+            registerTool(name: string, _config: unknown, handler: Handler) {
+                tools[name] = handler;
+            }
+        } as unknown as McpServer,
+        {
+            raw(name: string) {
+                return Promise.resolve(
+                    name === 'builds:download'
+                        ? { data: { id: 7 } }
+                        : {
+                              data: {
+                                  status: 'complete',
+                                  artifacts: [{ type: 'download', url: 'https://example.com/build.zip' }]
+                              }
+                          }
+                );
+            },
+            fail(name: string, message: string) {
+                return { name, message };
+            },
+            ok(name: string, data: unknown) {
+                return { name, data };
+            }
+        } as unknown as WSS
+    );
+    const options = {
+        name: 'Download',
+        sceneIds: [1],
+        format: 'static',
+        outputPath: path
+    };
+
+    assert.deepEqual(await tools.download_build(options), {
+        name: 'builds:download',
+        data: { buildId: 7, path, bytes: 5 }
+    });
+    content = 'second';
+    assert.match((await tools.download_build(options) as { message: string }).message, /EEXIST/);
+    assert.equal(await readFile(path, 'utf8'), 'first');
+    assert.deepEqual(await readdir(dir), ['build.zip']);
+
+    await tools.download_build({ ...options, overwrite: true });
+    assert.equal(await readFile(path, 'utf8'), 'second');
+    assert.deepEqual(await readdir(dir), ['build.zip']);
 });

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -4,7 +4,7 @@ import { test } from 'node:test';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { register as registerBuild } from '../src/tools/build.ts';
-import { register as registerProcessing } from '../src/tools/processing.ts';
+import { register as registerProcessing, SpritePropsSchema } from '../src/tools/processing.ts';
 import { register as registerViewport } from '../src/tools/viewport.ts';
 import type { WSS } from '../src/wss.ts';
 
@@ -77,4 +77,9 @@ test('processing, viewport, and build tools route stable driver methods', async 
         name: 'builds:download',
         message: 'start failed'
     });
+});
+
+test('sprite modification accepts tiled render mode', () => {
+    assert.equal(SpritePropsSchema.safeParse({ renderMode: 2 }).success, true);
+    assert.equal(SpritePropsSchema.safeParse({ renderMode: 3 }).success, false);
 });

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { register as registerBuild } from '../src/tools/build.ts';
+import { register as registerProcessing } from '../src/tools/processing.ts';
+import { register as registerViewport } from '../src/tools/viewport.ts';
+import type { WSS } from '../src/wss.ts';
+
+type Handler = (args: Record<string, unknown>) => unknown;
+
+const setup = () => {
+    const tools: Record<string, Handler> = {};
+    const calls: { name: string; args: unknown[] }[] = [];
+    const server = {
+        registerTool(name: string, _config: unknown, handler: Handler) {
+            tools[name] = handler;
+        }
+    } as unknown as McpServer;
+    const wss = {
+        call(name: string, ...args: unknown[]) {
+            calls.push({ name, args });
+            return { name, args };
+        },
+        raw(name: string, ...args: unknown[]) {
+            calls.push({ name, args });
+            return Promise.resolve({ error: 'start failed' });
+        },
+        fail(name: string, message: string) {
+            return { name, message };
+        }
+    } as unknown as WSS;
+    registerProcessing(server, wss);
+    registerViewport(server, wss);
+    registerBuild(server, wss);
+    return { tools, calls };
+};
+
+test('processing, viewport, and build tools route stable driver methods', async () => {
+    const { tools, calls } = setup();
+
+    tools.modify_bundle_asset({ id: 7, add: [8], remove: [9] });
+    assert.deepEqual(calls.at(-1), {
+        name: 'assets:bundle:modify',
+        args: [7, { add: [8], remove: [9] }]
+    });
+
+    tools.cancel_model_unwrap({ id: 7 });
+    assert.deepEqual(calls.at(-1), {
+        name: 'assets:model:unwrap:cancel',
+        args: [7]
+    });
+
+    tools.set_viewport_state({
+        cameraId: 'perspective',
+        projection: 'perspective'
+    });
+    assert.deepEqual(calls.at(-1), {
+        name: 'viewport:state:set',
+        args: [{ cameraId: 'perspective', projection: 'perspective' }]
+    });
+
+    tools.list_builds({ limit: 10, cursor: '20', status: 'complete' });
+    assert.deepEqual(calls.at(-1), {
+        name: 'builds:list',
+        args: [{ limit: 10, cursor: '20', filters: { status: 'complete' } }]
+    });
+
+    const failed = await tools.download_build({
+        name: 'Download',
+        sceneIds: [1],
+        format: 'static',
+        outputPath: '/tmp/download.zip'
+    });
+    assert.deepEqual(failed, {
+        name: 'builds:download',
+        message: 'start failed'
+    });
+});

--- a/test/vcs.test.ts
+++ b/test/vcs.test.ts
@@ -28,7 +28,7 @@ const connectFakeEditor = (port: number, answers: Record<string, unknown>) => {
     return new Promise<WebSocket>((resolve) => {
         const ws = new WebSocket(`ws://127.0.0.1:${port}`);
         ws.on('open', () => {
-            ws.send(JSON.stringify({ register: 'editor' }));
+            ws.send(JSON.stringify({ register: 'editor', protocolVersion: 1, methods: ['ping', ...Object.keys(answers)] }));
             resolve(ws);
         });
         ws.on('message', (buf) => {
@@ -110,7 +110,10 @@ test('vcs lifecycle tools: arg passthrough, apply_merge finalize reload, error p
     // a fake editor that records every method + args it receives, then answers
     const connect = () => new Promise<WebSocket>((resolve) => {
         const ws = new WebSocket(`ws://127.0.0.1:${PORT2}`);
-        ws.on('open', () => { ws.send(JSON.stringify({ register: 'editor' })); resolve(ws); });
+        ws.on('open', () => {
+            ws.send(JSON.stringify({ register: 'editor', protocolVersion: 1, methods: ['ping', ...Object.keys(answers)] }));
+            resolve(ws);
+        });
         ws.on('message', (buf) => {
             const msg = JSON.parse(buf.toString());
             if (!msg.name || msg.name === 'ping') return;

--- a/test/wss.test.ts
+++ b/test/wss.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { after, test } from 'node:test';
 
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { WebSocket } from 'ws';
 
 import { WSS } from '../src/wss.ts';
@@ -66,10 +67,22 @@ const PORT2 = 52998;
 const connectEditor = (port: number) => new Promise<WebSocket>((resolve) => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}`);
     ws.on('open', () => {
-        ws.send(JSON.stringify({ register: 'editor' }));
+        ws.send(JSON.stringify({ register: 'editor', protocolVersion: 1, methods: ['ping'] }));
         resolve(ws);
     });
+    ws.on('message', (data) => {
+        const { id } = JSON.parse(data.toString());
+        ws.send(JSON.stringify({ id, res: { data: 'pong' } }));
+    });
 });
+
+const envelope = (result: CallToolResult) => {
+    const item = result.content.find(item => item.type === 'text');
+    if (!item || item.type !== 'text') {
+        throw new Error('Missing text response');
+    }
+    return JSON.parse(item.text);
+};
 
 test('waitForEditor tracks editor connection generation', async () => {
     const wss2 = new WSS(PORT2);
@@ -89,10 +102,31 @@ test('waitForEditor tracks editor connection generation', async () => {
     const back = await wss2.waitForEditor(gen0, 2000);
     assert.equal(back, true, 'a freshly connected editor bumps the generation');
 
+    const pong = envelope(await wss2.call('ping'));
+    assert.equal(pong.meta.status, 'ok');
+    assert.equal(pong.data, 'pong');
+
+    const missing = envelope(await wss2.call('missing'));
+    assert.equal(missing.meta.status, 'error');
+    assert.match(missing.meta.message, /does not support 'missing'/);
+
     const gen1 = wss2.editorGeneration;
     const none = await wss2.waitForEditor(gen1, 300);
     assert.equal(none, false, 'no new editor within the timeout resolves false');
 
+    const legacy = await new Promise<WebSocket>((resolve) => {
+        const ws = new WebSocket(`ws://127.0.0.1:${PORT2}`);
+        ws.on('open', () => {
+            ws.send(JSON.stringify({ register: 'editor' }));
+            resolve(ws);
+        });
+    });
+    await wss2.waitForEditor(gen1, 2000);
+    const incompatible = envelope(await wss2.call('ping'));
+    assert.equal(incompatible.meta.status, 'error');
+    assert.match(incompatible.meta.message, /does not advertise protocol 1 capabilities/);
+
     ed.close();
+    legacy.close();
     wss2.close();
 });

--- a/test/wss.test.ts
+++ b/test/wss.test.ts
@@ -120,13 +120,31 @@ test('waitForEditor tracks editor connection generation', async () => {
             ws.send(JSON.stringify({ register: 'editor' }));
             resolve(ws);
         });
+        ws.on('message', (data) => {
+            const { id } = JSON.parse(data.toString());
+            ws.send(JSON.stringify({ id, res: { data: 'legacy pong' } }));
+        });
     });
     await wss2.waitForEditor(gen1, 2000);
+    const legacyPong = envelope(await wss2.call('ping'));
+    assert.equal(legacyPong.meta.status, 'ok');
+    assert.equal(legacyPong.data, 'legacy pong');
+
+    const gen2 = wss2.editorGeneration;
+    const incompatibleEditor = await new Promise<WebSocket>((resolve) => {
+        const ws = new WebSocket(`ws://127.0.0.1:${PORT2}`);
+        ws.on('open', () => {
+            ws.send(JSON.stringify({ register: 'editor', protocolVersion: 2, methods: ['ping'] }));
+            resolve(ws);
+        });
+    });
+    await wss2.waitForEditor(gen2, 2000);
     const incompatible = envelope(await wss2.call('ping'));
     assert.equal(incompatible.meta.status, 'error');
-    assert.match(incompatible.meta.message, /does not advertise protocol 1 capabilities/);
+    assert.match(incompatible.meta.message, /advertises incompatible protocol 2/);
 
     ed.close();
     legacy.close();
+    incompatibleEditor.close();
     wss2.close();
 });


### PR DESCRIPTION
Fixes #79

Requires playcanvas/editor#2161.

- Expose in-project MCP tools for assets, entities, scenes, animation, processing, viewport, and builds.
- Validate Editor capabilities before dispatch and return synchronous or asynchronous driver failures to callers.
- Keep every operation scoped to the project open in the connected Editor.

### Manual smoke test

1. Start the MCP server and open a designated project using the Editor changes from playcanvas/editor#2161; confirm the server registers the connected Editor.
2. List and edit assets and entities, then switch scenes; confirm each tool waits for the requested result in the open project.
3. Create animation states, transitions, conditions, parameters, and clip events; read them back and confirm invalid references are rejected.
4. Run a processing operation, capture the viewport, and download a build; confirm output files require explicit overwrite.