### PR TITLE
fix: reclaim only the listening PID on Windows port takeover

### DIFF
--- a/src/pids.ts
+++ b/src/pids.ts
@@ -1,0 +1,16 @@
+/**
+ * Deduped PIDs *listening* on `port`, parsed from raw lsof/netstat output. On Windows
+ * netstat also lists the port's client rows (ESTABLISHED/TIME_WAIT), so only LISTENING
+ * rows for the port are kept — else reclaiming the port would kill innocent clients
+ * (e.g. the browser). PID 0 is skipped.
+ */
+export const parsePids = (output: string, platform: NodeJS.Platform, port: number) => {
+    const lines = output.split('\n');
+    const pids = platform === 'win32' ?
+        lines
+            .map(l => l.trim().split(/\s+/)) // Proto Local Foreign State PID
+            .filter(c => c.length >= 5 && c[3] === 'LISTENING' && c[1].endsWith(`:${port}`))
+            .map(c => c[4]) :
+        lines.map(l => l.trim()); // lsof -t already filtered to LISTEN: one PID per line
+    return Array.from(new Set(pids.filter(p => /^\d+$/.test(p) && p !== '0')));
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { WebSocket } from 'ws';
 
 import pkg from '../package.json' with { type: 'json' };
 
+import { parsePids } from './pids.ts';
 import { register as registerAnimation } from './tools/animation.ts';
 import { register as registerAnimStateGraph } from './tools/animstategraph.ts';
 import { register as registerAsset } from './tools/asset.ts';
@@ -26,17 +27,13 @@ import { WSS } from './wss.ts';
 
 const PORT = parseInt(process.env.PORT || '52000', 10);
 
-// Return the *deduped* list of PIDs listening on the port. A single process can
-// produce multiple lsof/netstat lines (e.g. IPv4 + IPv6), so we must dedupe —
-// otherwise a multi-line result would break the kill command and deadlock.
+// deduped PIDs listening on the port; parsing lives in parsePids so it's unit-testable
 const findPids = (port: number): string[] => {
     try {
         const cmd = process.platform === 'win32' ?
-            `netstat -ano | findstr :${port}` :
+            'netstat -ano -p TCP' :
             `lsof -nP -iTCP:${port} -sTCP:LISTEN -t`;
-        const lines = execSync(cmd).toString().split('\n');
-        const pids = lines.map(line => line.trim().split(/\s+/).pop() || '').filter(p => /^\d+$/.test(p));
-        return Array.from(new Set(pids));
+        return parsePids(execSync(cmd).toString(), process.platform, port);
     } catch {
         // No listener (lsof/netstat exit non-zero when nothing matches).
         return [];

--- a/test/pids.test.ts
+++ b/test/pids.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+import { parsePids } from '../src/pids.ts';
+
+const PORT = 52000;
+
+// netstat dump with client rows (ESTABLISHED/TIME_WAIT), PID 0, and the real listener
+const NETSTAT = `
+Active Connections
+
+  Proto  Local Address          Foreign Address        State           PID
+  TCP    127.0.0.1:49176        127.0.0.1:52000        TIME_WAIT       0
+  TCP    127.0.0.1:51008        127.0.0.1:52000        ESTABLISHED     26960
+  TCP    127.0.0.1:52000        0.0.0.0:0              LISTENING       6612
+  TCP    127.0.0.1:52000        127.0.0.1:51008        ESTABLISHED     6612
+  TCP    [::]:52000             [::]:0                 LISTENING       6612
+  TCP    127.0.0.1:5200         0.0.0.0:0              LISTENING       999
+`;
+
+test('parsePids (win32) keeps only the LISTENING owner of the port', () => {
+    // 6612 is the sole listener (deduped IPv4+IPv6); excludes Chrome 26960, PID 0, :5200
+    assert.deepEqual(parsePids(NETSTAT, 'win32', PORT), ['6612']);
+});
+
+test('parsePids (win32) returns empty when nothing listens on the port', () => {
+    assert.deepEqual(parsePids(NETSTAT, 'win32', 40000), []);
+});
+
+test('parsePids (posix) takes lsof -t PIDs one per line and dedupes', () => {
+    // lsof -sTCP:LISTEN -t already filters to listeners: bare PIDs, one per line.
+    assert.deepEqual(parsePids('6612\n6612\n0\n', 'darwin', PORT), ['6612']);
+    assert.deepEqual(parsePids('', 'darwin', PORT), []);
+});


### PR DESCRIPTION
### What's Changed

On Windows, port takeover could force-kill the wrong processes. `findPids` ran `netstat -ano | findstr :<port>` and took the last column of **every** matching line — which includes the port's client rows (`ESTABLISHED`/`TIME_WAIT`), not just the `LISTENING` owner. Those PIDs then reached `taskkill /F /T`, so a starting instance could kill the browser's process (and PID 0) instead of the stale server.

- Windows now runs `netstat -ano -p TCP` and keeps only `LISTENING` rows whose local address is the target port; PID 0 is skipped.
- Parsing moved into a pure `parsePids` helper (`src/pids.ts`) so it's unit-testable without starting the server.
- The macOS/Linux `lsof -sTCP:LISTEN -t` path is unchanged (already listener-only).

Paired with playcanvas/editor (MCP client dials `127.0.0.1` instead of `localhost`), which fixes the launch-page runtime bridge never connecting on Windows.

### Testing

`npm test` — new `test/pids.test.ts` covers a netstat dump with client rows, PID 0, and the real listener; full suite green (21 tests).

### Manual smoke test

1. On Windows, connect the Editor via the MCP button, then open a launched page so a browser client is connected to port 52000.
   - Expected: editor and launch page both connected.
2. Start a second MCP server instance so it reclaims the port (e.g. `set MCP_TAKEOVER=1` and launch another client).
   - Expected: the stale server is replaced; the browser (Chrome) is **not** killed and the page stays open.
